### PR TITLE
WU 1.4: implement rhumb find CLI expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,4 @@ Work Unit 0.4 scaffold is complete and Work Unit 1.1 (AN score engine) is implem
 - Tier assignment (L1-L4)
 - `POST /v1/score` endpoint with persistence
 - `rhumb score <service>` CLI output with `--mode aggregate|execution|access`, `--json`, and `--dimensions`
+- `rhumb find <query>` CLI output with human-ranked results, `--limit`, and `--json`

--- a/docs/API.md
+++ b/docs/API.md
@@ -85,6 +85,35 @@ In v0.2, `score` remains a backward-compatible alias of `aggregate_recommendatio
 
 Fetch latest persisted score for a service. For the initial calibration set (`stripe`, `hubspot`, `sendgrid`, `resend`, `github`), this route can bootstrap from hand-scored fixtures when no DB row exists yet.
 
+## Search Endpoint
+
+### `GET /v1/search?q=<query>&limit=<n>`
+
+Search indexed services by free-text query. Used by `rhumb find <query>`.
+
+**Response body**
+
+```json
+{
+  "data": {
+    "query": "payment routing",
+    "results": [
+      {
+        "service_slug": "stripe",
+        "name": "Stripe",
+        "aggregate_recommendation_score": 8.9,
+        "tier": "L4",
+        "confidence": 0.95,
+        "why": "Best default for payment flows with strong reliability."
+      }
+    ]
+  },
+  "error": null
+}
+```
+
+`limit` is optional and can be used by clients to cap result count.
+
 ## Probe Endpoints
 
 ### `POST /v1/probes/run`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,3 +47,9 @@
 - category bars
 - optional dimension breakdown (`--dimensions`)
 - raw payload (`--json`)
+
+`rhumb find <query>` reads `GET /v1/search` and renders:
+- ranked service matches with score/tier/confidence
+- optional rationale lines (`why`/`reason`/`explanation`)
+- raw payload (`--json`)
+- result limit control (`--limit`)

--- a/packages/api/routes/search.py
+++ b/packages/api/routes/search.py
@@ -6,6 +6,7 @@ router = APIRouter()
 
 
 @router.get("/search")
-async def search_services(q: str) -> dict:
+async def search_services(q: str, limit: int = 10) -> dict:
     """Semantic search endpoint."""
-    return {"data": {"query": q, "results": []}, "error": None}
+    bounded_limit = max(1, min(limit, 50))
+    return {"data": {"query": q, "limit": bounded_limit, "results": []}, "error": None}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,9 +16,16 @@ rhumb score stripe
 rhumb score stripe --mode execution
 rhumb score stripe --mode access --dimensions
 rhumb score stripe --json
+rhumb find "payment routing"
+rhumb find "payment routing" --limit 5 --json
 ```
 
 `rhumb score` supports v0.2 dual-score output:
 - aggregate recommendation (`score` / `aggregate_recommendation_score`)
 - execution score (`execution_score`)
 - access readiness score (`access_readiness_score`)
+
+`rhumb find` queries `GET /v1/search` and supports:
+- human-ranked output (default)
+- raw payload output (`--json`)
+- result caps (`--limit`)

--- a/packages/cli/commands/find.py
+++ b/packages/cli/commands/find.py
@@ -1,8 +1,106 @@
 """`rhumb find` command."""
 
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
 import typer
 
+from client import RhumbAPIClient
+from formatting import render_output
 
-def find(query: str) -> None:
+
+def _extract_results(payload: dict[str, Any]) -> tuple[str, list[dict[str, Any]]]:
+    """Normalize search payload into query string + list of result objects."""
+    data = payload.get("data", payload)
+
+    if not isinstance(data, dict):
+        return "", []
+
+    query = str(data.get("query", ""))
+    raw_results = data.get("results", [])
+
+    if not isinstance(raw_results, list):
+        return query, []
+
+    normalized: list[dict[str, Any]] = []
+    for item in raw_results:
+        if isinstance(item, dict):
+            normalized.append(item)
+
+    return query, normalized
+
+
+def _render_human(payload: dict[str, Any], fallback_query: str) -> str:
+    query, results = _extract_results(payload)
+    display_query = query or fallback_query
+
+    lines = [
+        f'━━━ Find: "{display_query}" ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+        "",
+        f"  Results: {len(results)}",
+    ]
+
+    if not results:
+        lines.extend(["", "  No matching services found."])
+        return "\n".join(lines)
+
+    for index, result in enumerate(results, start=1):
+        slug = str(result.get("service_slug") or result.get("slug") or "unknown")
+        name = str(result.get("name") or slug.title())
+
+        score_raw = result.get("aggregate_recommendation_score", result.get("score"))
+        score = float(score_raw) if score_raw is not None else None
+
+        tier = result.get("tier")
+        confidence_raw = result.get("confidence")
+        confidence = float(confidence_raw) if confidence_raw is not None else None
+
+        rationale = (
+            result.get("why")
+            or result.get("reason")
+            or result.get("explanation")
+            or ""
+        )
+
+        score_text = "N/A" if score is None else f"{score:.1f}"
+        tier_text = str(tier) if tier else "N/A"
+        confidence_text = "N/A" if confidence is None else f"{confidence:.2f}"
+
+        lines.extend(
+            [
+                "",
+                f"  {index}. {name} ({slug})",
+                f"     Score: {score_text} | Tier: {tier_text} | Confidence: {confidence_text}",
+            ]
+        )
+
+        if rationale:
+            lines.append(f"     Why: {str(rationale)}")
+
+    return "\n".join(lines)
+
+
+def find(
+    query: str,
+    limit: int = typer.Option(10, "--limit", min=1, max=50, help="Maximum results to return."),
+    as_json: bool = typer.Option(False, "--json", help="Return raw JSON payload."),
+) -> None:
     """Search services by free-text query."""
-    typer.echo(f"find scaffold: query={query}")
+    client = RhumbAPIClient()
+
+    try:
+        payload = client.get("/search", params={"q": query, "limit": limit})
+    except httpx.HTTPStatusError as exc:
+        typer.echo(f"API error: {exc}")
+        raise typer.Exit(code=1) from exc
+    except httpx.HTTPError as exc:
+        typer.echo(f"API error: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if as_json:
+        typer.echo(render_output(payload, as_json=True))
+        return
+
+    typer.echo(_render_human(payload, fallback_query=query))

--- a/packages/cli/tests/test_commands.py
+++ b/packages/cli/tests/test_commands.py
@@ -171,3 +171,91 @@ def test_score_command_dimension_breakdown(monkeypatch: pytest.MonkeyPatch) -> N
     assert "Dimensions" in result.stdout
     assert "I1: 9.5" in result.stdout
     assert "O3: 8.0" in result.stdout
+
+
+def _sample_find_payload() -> dict[str, Any]:
+    return {
+        "data": {
+            "query": "payment routing",
+            "results": [
+                {
+                    "service_slug": "stripe",
+                    "name": "Stripe",
+                    "aggregate_recommendation_score": 8.9,
+                    "tier": "L4",
+                    "confidence": 0.95,
+                    "why": "Best default for payment flows with strong reliability.",
+                },
+                {
+                    "service_slug": "resend",
+                    "name": "Resend",
+                    "score": 8.1,
+                    "tier": "L3",
+                    "confidence": 0.89,
+                    "reason": "Strong API ergonomics for transactional notifications.",
+                },
+            ],
+        },
+        "error": None,
+    }
+
+
+def test_find_command_human_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Find command should render ranked service matches in human mode."""
+
+    def fake_get(
+        self: RhumbAPIClient,
+        path: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        assert path == "/search"
+        assert params == {"q": "payment routing", "limit": 10}
+        return _sample_find_payload()
+
+    monkeypatch.setattr(RhumbAPIClient, "get", fake_get)
+    result = runner.invoke(app, ["find", "payment routing"])
+
+    assert result.exit_code == 0
+    assert 'Find: "payment routing"' in result.stdout
+    assert "Results: 2" in result.stdout
+    assert "1. Stripe (stripe)" in result.stdout
+    assert "2. Resend (resend)" in result.stdout
+    assert "Why: Best default for payment flows" in result.stdout
+
+
+def test_find_command_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Find command should support --json mode."""
+
+    def fake_get(
+        self: RhumbAPIClient,
+        path: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        assert path == "/search"
+        assert params == {"q": "payment routing", "limit": 5}
+        return _sample_find_payload()
+
+    monkeypatch.setattr(RhumbAPIClient, "get", fake_get)
+    result = runner.invoke(app, ["find", "payment routing", "--limit", "5", "--json"])
+
+    assert result.exit_code == 0
+    assert '"query": "payment routing"' in result.stdout
+    assert '"service_slug": "stripe"' in result.stdout
+
+
+def test_find_command_no_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Find command should report an explicit empty state when no matches exist."""
+
+    def fake_get(
+        self: RhumbAPIClient,
+        path: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return {"data": {"query": "unknown", "results": []}, "error": None}
+
+    monkeypatch.setattr(RhumbAPIClient, "get", fake_get)
+    result = runner.invoke(app, ["find", "unknown"])
+
+    assert result.exit_code == 0
+    assert "Results: 0" in result.stdout
+    assert "No matching services found." in result.stdout


### PR DESCRIPTION
## Summary
- implement `rhumb find <query>` with human output and `--json`
- add `--limit` support and wire query params to `/v1/search`
- keep `rhumb score` behavior unchanged; extend CLI tests for find
- update API/architecture/CLI docs for new command

## Validation
- `.venv/bin/pytest packages/cli/tests/test_commands.py -q`
- `.venv/bin/pytest packages/api/tests/test_routes.py -q`