### PR TITLE
WU 1.2 follow-on: cadence guardrails + drift alert primitives

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -142,12 +142,30 @@ Example:
 {
   "service_slugs": ["stripe", "openai"],
   "sample_count": 3,
+  "base_interval_minutes": 30,
   "dry_run": false
 }
 ```
+
+Response includes `cadence_by_service` guardrails with:
+- `base_interval_minutes` (clamped to a minimum of 5 and maximum of 1440)
+- `next_interval_minutes` (failure-aware exponential backoff)
+- `consecutive_failures`
+- `jitter_seconds` (deterministic per service)
 
 ### `GET /v1/services/{slug}/probes/latest`
 
 Fetch the latest persisted probe result for a service (optional `probe_type` query param).
 
 For `probe_type=schema`, metadata includes `schema_signature_version=v2` and `schema_fingerprint_v2`, which are derived from nested response shape descriptors (semantic drift guardrail beyond top-level key lists).
+
+### `GET /v1/alerts`
+
+Fetch probe-derived drift alerts.
+
+Current primitive alert types:
+- `schema_drift` — latest schema fingerprint differs from previous schema probe
+- `latency_regression` — p95 health latency regressed beyond threshold versus previous probe
+
+Optional query params:
+- `limit` (default 50, max 100)

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -75,8 +75,10 @@ curl -X POST http://localhost:8000/v1/probes/schedule/run \
 ```bash
 curl -X POST http://localhost:8000/v1/probes/schedule/run \
   -H "Content-Type: application/json" \
-  -d '{"service_slugs": ["stripe", "openai", "hubspot"], "sample_count": 3}'
+  -d '{"service_slugs": ["stripe", "openai", "hubspot"], "sample_count": 3, "base_interval_minutes": 30}'
 ```
+
+Batch responses now include `cadence_by_service` with guardrails (`base_interval_minutes`, `next_interval_minutes`, `consecutive_failures`, `jitter_seconds`).
 
 ### Fetch latest probe for a service
 
@@ -85,6 +87,14 @@ curl "http://localhost:8000/v1/services/stripe/probes/latest?probe_type=health"
 ```
 
 Schema probes now persist a semantic shape fingerprint (`schema_fingerprint_v2`) derived from nested response structure, not only top-level keys.
+
+### Fetch drift alerts
+
+```bash
+curl "http://localhost:8000/v1/alerts?limit=20"
+```
+
+Current primitive alerts: `schema_drift` and `latency_regression`.
 
 ### Cron wiring example
 

--- a/packages/api/db/repository.py
+++ b/packages/api/db/repository.py
@@ -89,6 +89,13 @@ class ProbeRepository(Protocol):
         self, service_slug: str, probe_type: str | None = None
     ) -> StoredProbe | None: ...
 
+    def list_recent_probes(
+        self,
+        service_slug: str,
+        probe_type: str | None = None,
+        limit: int = 10,
+    ) -> list[StoredProbe]: ...
+
 
 @dataclass(slots=True)
 class InMemoryScoreRepository:
@@ -188,6 +195,20 @@ class InMemoryProbeRepository:
             return None
         min_utc = datetime.min.replace(tzinfo=timezone.utc)
         return sorted(matches, key=lambda row: row.probed_at or min_utc)[-1]
+
+    def list_recent_probes(
+        self,
+        service_slug: str,
+        probe_type: str | None = None,
+        limit: int = 10,
+    ) -> list[StoredProbe]:
+        matches = [row for row in self._rows if row.service_slug == service_slug]
+        if probe_type:
+            matches = [row for row in matches if row.probe_type == probe_type]
+
+        min_utc = datetime.min.replace(tzinfo=timezone.utc)
+        ordered = sorted(matches, key=lambda row: row.probed_at or min_utc, reverse=True)
+        return ordered[: max(1, limit)]
 
 
 class SQLAlchemyScoreRepository:
@@ -471,3 +492,35 @@ class SQLAlchemyProbeRepository:
                 runner_version=runner_version,
                 trigger_source=trigger_source,
             )
+
+    def list_recent_probes(
+        self,
+        service_slug: str,
+        probe_type: str | None = None,
+        limit: int = 10,
+    ) -> list[StoredProbe]:
+        if not self._initialized:
+            self.create_tables()
+
+        with self._sessionmaker() as session:
+            stmt = (
+                select(ProbeResult, Service.slug, ProbeRun.runner_version, ProbeRun.trigger_source)
+                .join(Service, Service.id == ProbeResult.service_id)
+                .outerjoin(ProbeRun, ProbeRun.id == ProbeResult.run_id)
+                .where(Service.slug == service_slug)
+                .order_by(ProbeResult.probed_at.desc())
+                .limit(max(1, limit))
+            )
+            if probe_type:
+                stmt = stmt.where(ProbeResult.probe_type == probe_type)
+
+            rows = session.execute(stmt).all()
+            return [
+                self._to_stored_probe(
+                    probe_record,
+                    service_slug=slug,
+                    runner_version=runner_version,
+                    trigger_source=trigger_source,
+                )
+                for probe_record, slug, runner_version, trigger_source in rows
+            ]

--- a/packages/api/routes/probes.py
+++ b/packages/api/routes/probes.py
@@ -102,6 +102,10 @@ async def run_scheduled_probe_batch(
     selected = scheduler.list_specs(service_slugs=payload.service_slugs)
 
     if payload.dry_run:
+        cadence_preview = scheduler.preview_cadence(
+            selected_specs=selected,
+            base_interval_minutes=payload.base_interval_minutes,
+        )
         return ProbeBatchRunResponseSchema(
             total_specs=len(scheduler.list_specs()),
             selected_services=[spec.service_slug for spec in selected],
@@ -110,11 +114,13 @@ async def run_scheduled_probe_batch(
             failed=0,
             probe_ids=[],
             by_service={},
+            cadence_by_service=cadence_preview,
         )
 
     summary = await scheduler.run_once(
         service_slugs=payload.service_slugs,
         sample_count=payload.sample_count,
+        base_interval_minutes=payload.base_interval_minutes,
     )
 
     return ProbeBatchRunResponseSchema(
@@ -125,6 +131,7 @@ async def run_scheduled_probe_batch(
         failed=summary.failed,
         probe_ids=summary.probe_ids,
         by_service=summary.by_service,
+        cadence_by_service=summary.cadence_by_service,
     )
 
 

--- a/packages/api/routes/scores.py
+++ b/packages/api/routes/scores.py
@@ -19,7 +19,9 @@ from db.repository import (
     StoredScore,
 )
 from schemas.score import ANScoreSchema, ScoreRequestSchema
+from services.alerts import ProbeAlertService
 from services.fixtures import HAND_SCORED_FIXTURES
+from services.probe_scheduler import DEFAULT_PROBE_SPECS
 from services.scoring import EvidenceInput, ScoringService, TIER_LABELS
 
 router = APIRouter()
@@ -368,6 +370,32 @@ async def evaluate_stack() -> dict:
 
 
 @router.get("/alerts")
-async def get_alerts() -> dict:
-    """Fetch schema/score change alerts for authenticated users."""
-    return {"data": {"alerts": []}, "error": None}
+async def get_alerts(limit: int = 50) -> dict:
+    """Fetch schema/score change alerts derived from probe telemetry."""
+    safe_limit = max(1, min(limit, 100))
+    service_slugs = [spec.service_slug for spec in DEFAULT_PROBE_SPECS]
+    alert_service = ProbeAlertService(
+        repository=get_probe_repository(),
+        watched_services=service_slugs,
+    )
+    alerts = alert_service.generate_alerts(limit=safe_limit)
+
+    return {
+        "data": {
+            "alerts": [
+                {
+                    "id": alert.id,
+                    "type": alert.type,
+                    "severity": alert.severity,
+                    "service_slug": alert.service_slug,
+                    "probe_type": alert.probe_type,
+                    "title": alert.title,
+                    "summary": alert.summary,
+                    "details": alert.details,
+                    "detected_at": alert.detected_at,
+                }
+                for alert in alerts
+            ]
+        },
+        "error": None,
+    }

--- a/packages/api/schemas/probe.py
+++ b/packages/api/schemas/probe.py
@@ -23,6 +23,7 @@ class ProbeBatchRunRequestSchema(BaseModel):
 
     service_slugs: list[str] | None = None
     sample_count: int = Field(default=3, ge=1, le=20)
+    base_interval_minutes: int = Field(default=30, ge=1, le=1440)
     dry_run: bool = False
 
 
@@ -36,6 +37,7 @@ class ProbeBatchRunResponseSchema(BaseModel):
     failed: int
     probe_ids: list[str]
     by_service: dict[str, str]
+    cadence_by_service: dict[str, dict[str, int]]
 
 
 class ProbeResultSchema(BaseModel):

--- a/packages/api/services/alerts.py
+++ b/packages/api/services/alerts.py
@@ -1,0 +1,175 @@
+"""Probe-derived alert primitives (schema drift + latency regression)."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from db.repository import ProbeRepository, StoredProbe
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeAlert:
+    """Serializable alert payload for `/v1/alerts`."""
+
+    id: str
+    type: str
+    severity: str
+    service_slug: str
+    probe_type: str
+    title: str
+    summary: str
+    details: dict[str, object]
+    detected_at: str
+
+
+class ProbeAlertService:
+    """Derive lightweight user-facing alerts from probe telemetry."""
+
+    def __init__(
+        self,
+        repository: ProbeRepository,
+        watched_services: list[str],
+        latency_regression_ratio: float = 1.5,
+        latency_regression_min_delta_ms: int = 75,
+    ) -> None:
+        self._repository = repository
+        self._watched_services = watched_services
+        self._latency_regression_ratio = latency_regression_ratio
+        self._latency_regression_min_delta_ms = latency_regression_min_delta_ms
+
+    @staticmethod
+    def _iso(value: datetime | None) -> str:
+        now = datetime.now(timezone.utc)
+        if value is None:
+            return now.isoformat()
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc).isoformat()
+        return value.isoformat()
+
+    @staticmethod
+    def _alert_id(*parts: object) -> str:
+        payload = "::".join(str(part) for part in parts)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+    @staticmethod
+    def _schema_fingerprint(probe: StoredProbe | None) -> str | None:
+        if probe is None:
+            return None
+        metadata = probe.probe_metadata or {}
+        v2 = metadata.get("schema_fingerprint_v2")
+        if isinstance(v2, str) and v2:
+            return v2
+        fallback = probe.response_schema_hash
+        return fallback if isinstance(fallback, str) and fallback else None
+
+    @staticmethod
+    def _latency_p95(probe: StoredProbe | None) -> int | None:
+        if probe is None:
+            return None
+        metadata = probe.probe_metadata or {}
+        distribution = metadata.get("latency_distribution_ms")
+        if isinstance(distribution, dict):
+            p95 = distribution.get("p95")
+            if p95 is not None:
+                try:
+                    return int(p95)
+                except (TypeError, ValueError):
+                    return None
+
+        if probe.latency_ms is None:
+            return None
+        return int(probe.latency_ms)
+
+    def _schema_alert(self, service_slug: str) -> ProbeAlert | None:
+        recent = self._repository.list_recent_probes(
+            service_slug=service_slug,
+            probe_type="schema",
+            limit=2,
+        )
+        if len(recent) < 2:
+            return None
+
+        latest, previous = recent[0], recent[1]
+        latest_fp = self._schema_fingerprint(latest)
+        previous_fp = self._schema_fingerprint(previous)
+        if not latest_fp or not previous_fp:
+            return None
+        if latest_fp == previous_fp:
+            return None
+
+        detected_at = self._iso(latest.probed_at)
+        return ProbeAlert(
+            id=self._alert_id("schema", service_slug, latest_fp, previous_fp),
+            type="schema_drift",
+            severity="high",
+            service_slug=service_slug,
+            probe_type="schema",
+            title=f"Schema drift detected for {service_slug}",
+            summary="Latest schema fingerprint changed from the prior probe run.",
+            details={
+                "latest_fingerprint": latest_fp,
+                "previous_fingerprint": previous_fp,
+                "latest_probe_id": str(latest.id),
+                "previous_probe_id": str(previous.id),
+            },
+            detected_at=detected_at,
+        )
+
+    def _latency_alert(self, service_slug: str) -> ProbeAlert | None:
+        recent = self._repository.list_recent_probes(
+            service_slug=service_slug,
+            probe_type="health",
+            limit=2,
+        )
+        if len(recent) < 2:
+            return None
+
+        latest, previous = recent[0], recent[1]
+        latest_p95 = self._latency_p95(latest)
+        previous_p95 = self._latency_p95(previous)
+        if latest_p95 is None or previous_p95 is None or previous_p95 <= 0:
+            return None
+
+        ratio = latest_p95 / previous_p95
+        delta = latest_p95 - previous_p95
+        if ratio < self._latency_regression_ratio:
+            return None
+        if delta < self._latency_regression_min_delta_ms:
+            return None
+
+        detected_at = self._iso(latest.probed_at)
+        return ProbeAlert(
+            id=self._alert_id("latency", service_slug, latest_p95, previous_p95),
+            type="latency_regression",
+            severity="medium",
+            service_slug=service_slug,
+            probe_type="health",
+            title=f"Latency regression for {service_slug}",
+            summary="Probe p95 latency regressed versus the previous probe.",
+            details={
+                "latest_p95_ms": latest_p95,
+                "previous_p95_ms": previous_p95,
+                "regression_ratio": round(ratio, 2),
+                "delta_ms": delta,
+                "latest_probe_id": str(latest.id),
+                "previous_probe_id": str(previous.id),
+            },
+            detected_at=detected_at,
+        )
+
+    def generate_alerts(self, limit: int = 50) -> list[ProbeAlert]:
+        alerts: list[ProbeAlert] = []
+
+        for service_slug in self._watched_services:
+            schema_alert = self._schema_alert(service_slug)
+            if schema_alert is not None:
+                alerts.append(schema_alert)
+
+            latency_alert = self._latency_alert(service_slug)
+            if latency_alert is not None:
+                alerts.append(latency_alert)
+
+        alerts.sort(key=lambda alert: alert.detected_at, reverse=True)
+        return alerts[: max(1, limit)]

--- a/packages/api/services/probe_scheduler.py
+++ b/packages/api/services/probe_scheduler.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from typing import Any, Sequence
 
 from services.probes import ProbeService
+
+MIN_INTERVAL_MINUTES = 5
+MAX_INTERVAL_MINUTES = 24 * 60
+MAX_BACKOFF_POWER = 3
+MAX_JITTER_SHARE = 0.1
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,6 +43,16 @@ DEFAULT_PROBE_SPECS: tuple[ProbeSpec, ...] = (
 )
 
 
+@dataclass(frozen=True, slots=True)
+class ProbeCadenceDecision:
+    """Cadence policy output for a service after probe execution."""
+
+    base_interval_minutes: int
+    next_interval_minutes: int
+    consecutive_failures: int
+    jitter_seconds: int
+
+
 @dataclass(slots=True)
 class ProbeBatchRunSummary:
     """Execution summary for a scheduler-triggered probe batch."""
@@ -48,6 +64,7 @@ class ProbeBatchRunSummary:
     failed: int
     probe_ids: list[str]
     by_service: dict[str, str]
+    cadence_by_service: dict[str, dict[str, int]]
 
 
 class ProbeScheduler:
@@ -61,18 +78,96 @@ class ProbeScheduler:
         self._probe_service = probe_service
         self._specs = tuple(specs or DEFAULT_PROBE_SPECS)
 
+    @staticmethod
+    def _normalize_interval_minutes(interval_minutes: int) -> int:
+        return max(MIN_INTERVAL_MINUTES, min(MAX_INTERVAL_MINUTES, int(interval_minutes)))
+
+    @classmethod
+    def _deterministic_jitter_seconds(cls, service_slug: str, interval_minutes: int) -> int:
+        max_jitter = int(interval_minutes * 60 * MAX_JITTER_SHARE)
+        if max_jitter <= 0:
+            return 0
+
+        digest = hashlib.sha256(service_slug.encode("utf-8")).hexdigest()
+        return int(digest[:8], 16) % (max_jitter + 1)
+
+    @classmethod
+    def _decision_from_failure_count(
+        cls,
+        service_slug: str,
+        base_interval_minutes: int,
+        consecutive_failures: int,
+    ) -> ProbeCadenceDecision:
+        normalized_base = cls._normalize_interval_minutes(base_interval_minutes)
+        bounded_failures = max(0, int(consecutive_failures))
+        backoff_multiplier = 2 ** min(bounded_failures, MAX_BACKOFF_POWER)
+        next_interval = cls._normalize_interval_minutes(normalized_base * backoff_multiplier)
+
+        return ProbeCadenceDecision(
+            base_interval_minutes=normalized_base,
+            next_interval_minutes=next_interval,
+            consecutive_failures=bounded_failures,
+            jitter_seconds=cls._deterministic_jitter_seconds(service_slug, next_interval),
+        )
+
+    def _consecutive_failures(self, service_slug: str, probe_type: str) -> int:
+        recent = self._probe_service.list_recent_probes(
+            service_slug=service_slug,
+            probe_type=probe_type,
+            limit=6,
+        )
+        failures = 0
+        for probe in recent:
+            if probe.status == "ok":
+                break
+            failures += 1
+        return failures
+
     def list_specs(self, service_slugs: list[str] | None = None) -> list[ProbeSpec]:
         """Return selected probe specs, optionally filtered by service slug."""
-        if not service_slugs:
-            return list(self._specs)
+        if service_slugs:
+            allowed = set(service_slugs)
+            candidate = [spec for spec in self._specs if spec.service_slug in allowed]
+        else:
+            candidate = list(self._specs)
 
-        allowed = set(service_slugs)
-        return [spec for spec in self._specs if spec.service_slug in allowed]
+        selected: list[ProbeSpec] = []
+        seen_services: set[str] = set()
+        for spec in candidate:
+            if spec.service_slug in seen_services:
+                continue
+            seen_services.add(spec.service_slug)
+            selected.append(spec)
+
+        return selected
+
+    def preview_cadence(
+        self,
+        selected_specs: Sequence[ProbeSpec],
+        base_interval_minutes: int,
+    ) -> dict[str, dict[str, int]]:
+        """Compute cadence decisions without executing probes."""
+        cadence_by_service: dict[str, dict[str, int]] = {}
+        for spec in selected_specs:
+            failure_count = self._consecutive_failures(spec.service_slug, spec.probe_type)
+            cadence = self._decision_from_failure_count(
+                spec.service_slug,
+                base_interval_minutes,
+                consecutive_failures=failure_count,
+            )
+            cadence_by_service[spec.service_slug] = {
+                "base_interval_minutes": cadence.base_interval_minutes,
+                "next_interval_minutes": cadence.next_interval_minutes,
+                "consecutive_failures": cadence.consecutive_failures,
+                "jitter_seconds": cadence.jitter_seconds,
+            }
+        return cadence_by_service
 
     async def run_once(
         self,
         service_slugs: list[str] | None = None,
         sample_count: int = 3,
+        base_interval_minutes: int = 30,
     ) -> ProbeBatchRunSummary:
         """Execute one scheduler batch and return a summary payload."""
         selected = self.list_specs(service_slugs=service_slugs)
@@ -82,6 +177,7 @@ class ProbeScheduler:
         executed = 0
         probe_ids: list[str] = []
         by_service: dict[str, str] = {}
+        cadence_by_service: dict[str, dict[str, int]] = {}
 
         for spec in selected:
             stored = await self._probe_service.run_probe(
@@ -97,6 +193,17 @@ class ProbeScheduler:
             if stored is None:
                 failed += 1
                 by_service[spec.service_slug] = "not_persisted"
+                cadence = self._decision_from_failure_count(
+                    spec.service_slug,
+                    base_interval_minutes,
+                    consecutive_failures=1,
+                )
+                cadence_by_service[spec.service_slug] = {
+                    "base_interval_minutes": cadence.base_interval_minutes,
+                    "next_interval_minutes": cadence.next_interval_minutes,
+                    "consecutive_failures": cadence.consecutive_failures,
+                    "jitter_seconds": cadence.jitter_seconds,
+                }
                 continue
 
             probe_ids.append(str(stored.id))
@@ -107,6 +214,19 @@ class ProbeScheduler:
             else:
                 failed += 1
 
+            failure_count = self._consecutive_failures(spec.service_slug, spec.probe_type)
+            cadence = self._decision_from_failure_count(
+                spec.service_slug,
+                base_interval_minutes,
+                consecutive_failures=failure_count,
+            )
+            cadence_by_service[spec.service_slug] = {
+                "base_interval_minutes": cadence.base_interval_minutes,
+                "next_interval_minutes": cadence.next_interval_minutes,
+                "consecutive_failures": cadence.consecutive_failures,
+                "jitter_seconds": cadence.jitter_seconds,
+            }
+
         return ProbeBatchRunSummary(
             total_specs=len(self._specs),
             selected_services=[spec.service_slug for spec in selected],
@@ -115,4 +235,5 @@ class ProbeScheduler:
             failed=failed,
             probe_ids=probe_ids,
             by_service=by_service,
+            cadence_by_service=cadence_by_service,
         )

--- a/packages/api/services/probes.py
+++ b/packages/api/services/probes.py
@@ -334,3 +334,18 @@ class ProbeService:
         if self._repository is None:
             return None
         return self._repository.fetch_latest_probe(service_slug=service_slug, probe_type=probe_type)
+
+    def list_recent_probes(
+        self,
+        service_slug: str,
+        probe_type: str | None = None,
+        limit: int = 10,
+    ) -> list[StoredProbe]:
+        """Fetch a descending list of recent probes for a service."""
+        if self._repository is None:
+            return []
+        return self._repository.list_recent_probes(
+            service_slug=service_slug,
+            probe_type=probe_type,
+            limit=limit,
+        )

--- a/packages/api/tests/test_alerts.py
+++ b/packages/api/tests/test_alerts.py
@@ -1,0 +1,78 @@
+"""Alert route coverage for probe-derived drift primitives."""
+
+from __future__ import annotations
+
+import pytest
+
+from db.repository import InMemoryProbeRepository
+
+
+@pytest.fixture
+def probe_repository() -> InMemoryProbeRepository:
+    return InMemoryProbeRepository()
+
+
+def test_alerts_route_emits_schema_drift_alert(client, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Schema fingerprint changes should surface as schema_drift alerts."""
+    from routes import scores as score_routes
+
+    score_routes.get_probe_repository.cache_clear()
+    repository = InMemoryProbeRepository()
+
+    repository.save_probe(
+        service_slug="stripe",
+        probe_type="schema",
+        status="ok",
+        response_schema_hash="schema-old",
+        probe_metadata={"schema_fingerprint_v2": "schema-old"},
+    )
+    repository.save_probe(
+        service_slug="stripe",
+        probe_type="schema",
+        status="ok",
+        response_schema_hash="schema-new",
+        probe_metadata={"schema_fingerprint_v2": "schema-new"},
+    )
+
+    monkeypatch.setattr(score_routes, "get_probe_repository", lambda: repository)
+
+    response = client.get("/v1/alerts")
+    assert response.status_code == 200
+
+    body = response.json()
+    alerts = body["data"]["alerts"]
+    assert any(alert["type"] == "schema_drift" for alert in alerts)
+
+
+def test_alerts_route_emits_latency_regression_alert(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Health probe p95 regressions should emit latency_regression alerts."""
+    from routes import scores as score_routes
+
+    score_routes.get_probe_repository.cache_clear()
+    repository = InMemoryProbeRepository()
+
+    repository.save_probe(
+        service_slug="openai",
+        probe_type="health",
+        status="ok",
+        latency_ms=90,
+        probe_metadata={"latency_distribution_ms": {"p50": 80, "p95": 100, "p99": 120}},
+    )
+    repository.save_probe(
+        service_slug="openai",
+        probe_type="health",
+        status="ok",
+        latency_ms=210,
+        probe_metadata={"latency_distribution_ms": {"p50": 170, "p95": 210, "p99": 260}},
+    )
+
+    monkeypatch.setattr(score_routes, "get_probe_repository", lambda: repository)
+
+    response = client.get("/v1/alerts")
+    assert response.status_code == 200
+
+    body = response.json()
+    alerts = body["data"]["alerts"]
+    assert any(alert["type"] == "latency_regression" for alert in alerts)

--- a/packages/api/tests/test_probe_routes.py
+++ b/packages/api/tests/test_probe_routes.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from uuid import uuid4
+
 import pytest
 
-from db.repository import InMemoryProbeRepository
+from db.repository import InMemoryProbeRepository, StoredProbe
 from services.probe_scheduler import ProbeScheduler, ProbeSpec
 from services.probes import ProbeService
 
@@ -147,6 +150,9 @@ def test_scheduler_entrypoint_runs_seed_specs(client, monkeypatch: pytest.Monkey
     assert len(body["probe_ids"]) == 2
     assert body["by_service"]["stripe"] == "ok"
     assert body["by_service"]["openai"] == "ok"
+    assert body["cadence_by_service"]["stripe"]["base_interval_minutes"] == 30
+    assert body["cadence_by_service"]["stripe"]["next_interval_minutes"] >= 5
+    assert body["cadence_by_service"]["stripe"]["next_interval_minutes"] <= 1440
 
     latest_response = client.get("/v1/services/stripe/probes/latest")
     assert latest_response.status_code == 200
@@ -178,3 +184,99 @@ def test_scheduler_entrypoint_supports_dry_run(client, monkeypatch: pytest.Monke
     assert body["succeeded"] == 0
     assert body["failed"] == 0
     assert body["probe_ids"] == []
+    assert body["cadence_by_service"]["stripe"]["base_interval_minutes"] == 30
+
+
+def test_scheduler_guardrails_apply_interval_floor_and_failure_backoff(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cadence policy should clamp base interval and back off on repeated failures."""
+    from routes import probes as probe_routes
+
+    class StubProbeService:
+        async def run_probe(
+            self,
+            service_slug: str,
+            probe_type: str = "health",
+            target_url: str | None = None,
+            payload: dict | None = None,
+            trigger_source: str = "internal",
+            sample_count: int = 1,
+        ) -> StoredProbe:
+            return StoredProbe(
+                id=uuid4(),
+                run_id=uuid4(),
+                service_slug=service_slug,
+                probe_type=probe_type,
+                status="error",
+                latency_ms=180,
+                response_code=500,
+                response_schema_hash=None,
+                raw_response={"error": "boom"},
+                probe_metadata={"latency_distribution_ms": {"p50": 180, "p95": 220, "p99": 260}},
+                runner_version="scaffold-v1",
+                trigger_source=trigger_source,
+                probed_at=datetime.now(timezone.utc),
+            )
+
+        def list_recent_probes(
+            self,
+            service_slug: str,
+            probe_type: str | None = None,
+            limit: int = 10,
+        ) -> list[StoredProbe]:
+            now = datetime.now(timezone.utc)
+            return [
+                StoredProbe(
+                    id=uuid4(),
+                    run_id=uuid4(),
+                    service_slug=service_slug,
+                    probe_type=probe_type or "health",
+                    status="error",
+                    latency_ms=250,
+                    response_code=500,
+                    response_schema_hash=None,
+                    raw_response={"error": "recent-failure-1"},
+                    probe_metadata=None,
+                    runner_version="scaffold-v1",
+                    trigger_source="scheduler",
+                    probed_at=now,
+                ),
+                StoredProbe(
+                    id=uuid4(),
+                    run_id=uuid4(),
+                    service_slug=service_slug,
+                    probe_type=probe_type or "health",
+                    status="error",
+                    latency_ms=240,
+                    response_code=500,
+                    response_schema_hash=None,
+                    raw_response={"error": "recent-failure-2"},
+                    probe_metadata=None,
+                    runner_version="scaffold-v1",
+                    trigger_source="scheduler",
+                    probed_at=now,
+                ),
+            ]
+
+    probe_routes.get_probe_service.cache_clear()
+    probe_routes.get_probe_scheduler.cache_clear()
+
+    scheduler = ProbeScheduler(
+        probe_service=StubProbeService(),
+        specs=[ProbeSpec(service_slug="stripe")],
+    )
+    monkeypatch.setattr(probe_routes, "get_probe_scheduler", lambda: scheduler)
+
+    response = client.post(
+        "/v1/probes/schedule/run",
+        json={"service_slugs": ["stripe"], "base_interval_minutes": 1},
+    )
+    assert response.status_code == 200
+
+    body = response.json()
+    cadence = body["cadence_by_service"]["stripe"]
+    assert cadence["base_interval_minutes"] == 5
+    assert cadence["consecutive_failures"] == 2
+    assert cadence["next_interval_minutes"] == 20


### PR DESCRIPTION
## Summary
- add scheduler cadence guardrails (interval floor/ceiling, deterministic jitter, failure backoff)
- add probe repository/service recent-history support for policy and alert derivation
- implement probe-derived alert primitives (`schema_drift`, `latency_regression`) and wire `/v1/alerts`
- expand scheduler route/schema and tests for cadence policy output
- document cadence response and alerts route in API docs

## Validation
- `.venv/bin/black --check packages/api`
- `.venv/bin/pytest packages/api/tests -q`
- `.venv/bin/pytest packages/cli/tests -q`
