### PR TITLE
Round 6 Slice A: battery YAML schema/parser + tests

### DIFF
--- a/packages/api/batteries/stripe-health.yaml
+++ b/packages/api/batteries/stripe-health.yaml
@@ -1,0 +1,15 @@
+version: 1
+service_slug: stripe
+profile: default
+steps:
+  - id: health
+    kind: http
+    method: GET
+    url: https://api.stripe.com/v1/charges?limit=1
+    expect_status: [200]
+    timeout_ms: 8000
+    retries: 1
+  - id: schema
+    kind: schema_capture
+    source_step: health
+    fingerprint: semantic_v2

--- a/packages/api/requirements.txt
+++ b/packages/api/requirements.txt
@@ -7,3 +7,4 @@ sqlalchemy==2.0.35
 psycopg[binary]==3.2.3
 httpx==0.27.2
 python-dotenv==1.0.1
+PyYAML==6.0.2

--- a/packages/api/schemas/tester_fleet.py
+++ b/packages/api/schemas/tester_fleet.py
@@ -1,0 +1,82 @@
+"""Tester fleet battery schema definitions."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class HttpBatteryStep(BaseModel):
+    """HTTP request step for tester fleet batteries."""
+
+    id: str = Field(min_length=1)
+    kind: Literal["http"]
+    method: Literal["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"] = "GET"
+    url: str = Field(min_length=1)
+    expect_status: list[int] = Field(default_factory=lambda: [200], min_length=1)
+    timeout_ms: int = Field(default=8000, ge=100, le=120000)
+    retries: int = Field(default=0, ge=0, le=5)
+
+
+class SchemaCaptureBatteryStep(BaseModel):
+    """Schema capture step that fingerprints a previous response payload."""
+
+    id: str = Field(min_length=1)
+    kind: Literal["schema_capture"]
+    source_step: str = Field(min_length=1)
+    fingerprint: Literal["semantic_v2"] = "semantic_v2"
+
+
+class IdempotencyCheckBatteryStep(BaseModel):
+    """Replay/idempotency validation against a prior HTTP step."""
+
+    id: str = Field(min_length=1)
+    kind: Literal["idempotency_check"]
+    source_step: str = Field(min_length=1)
+    compare: Literal["status_class", "body_hash"] = "status_class"
+
+
+BatteryStep = Annotated[
+    HttpBatteryStep | SchemaCaptureBatteryStep | IdempotencyCheckBatteryStep,
+    Field(discriminator="kind"),
+]
+
+
+class BatteryDefinition(BaseModel):
+    """Top-level battery document parsed from YAML."""
+
+    version: Literal[1]
+    service_slug: str = Field(min_length=1)
+    profile: str = Field(default="default", min_length=1)
+    steps: list[BatteryStep] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_step_graph(self) -> "BatteryDefinition":
+        """Ensure deterministic, valid step references and unique IDs."""
+        step_by_id: dict[str, BatteryStep] = {}
+
+        for step in self.steps:
+            if step.id in step_by_id:
+                raise ValueError(f"Duplicate step id: {step.id}")
+
+            if isinstance(step, SchemaCaptureBatteryStep | IdempotencyCheckBatteryStep):
+                source = step_by_id.get(step.source_step)
+                if source is None:
+                    raise ValueError(
+                        f"Step '{step.id}' references unknown or future source_step '{step.source_step}'"
+                    )
+
+                if isinstance(step, IdempotencyCheckBatteryStep) and not isinstance(
+                    source, HttpBatteryStep
+                ):
+                    raise ValueError(
+                        f"Step '{step.id}' requires source_step '{step.source_step}' to be an http step"
+                    )
+
+            step_by_id[step.id] = step
+
+        if not any(isinstance(step, HttpBatteryStep) for step in self.steps):
+            raise ValueError("Battery must include at least one http step")
+
+        return self

--- a/packages/api/services/tester_fleet.py
+++ b/packages/api/services/tester_fleet.py
@@ -1,0 +1,49 @@
+"""Parser utilities for tester fleet battery YAML definitions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import ValidationError
+
+from schemas.tester_fleet import BatteryDefinition
+
+
+class BatteryParseError(ValueError):
+    """Raised when a battery definition cannot be parsed or validated."""
+
+
+def parse_battery_yaml(raw_yaml: str) -> BatteryDefinition:
+    """Parse and validate a tester fleet battery definition from YAML text."""
+    try:
+        payload = yaml.safe_load(raw_yaml)
+    except yaml.YAMLError as exc:
+        raise BatteryParseError(f"Invalid YAML syntax: {exc}") from exc
+
+    if payload is None:
+        raise BatteryParseError("Battery YAML is empty")
+
+    if not isinstance(payload, dict):
+        raise BatteryParseError("Battery YAML root must be an object")
+
+    return _validate_payload(payload)
+
+
+def load_battery_file(path: str | Path) -> BatteryDefinition:
+    """Read, parse, and validate a battery YAML file from disk."""
+    file_path = Path(path)
+    try:
+        raw_yaml = file_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise BatteryParseError(f"Unable to read battery file '{file_path}': {exc}") from exc
+
+    return parse_battery_yaml(raw_yaml)
+
+
+def _validate_payload(payload: dict[str, Any]) -> BatteryDefinition:
+    try:
+        return BatteryDefinition.model_validate(payload)
+    except ValidationError as exc:
+        raise BatteryParseError(f"Invalid battery definition: {exc}") from exc

--- a/packages/api/tests/test_tester_fleet.py
+++ b/packages/api/tests/test_tester_fleet.py
@@ -1,0 +1,132 @@
+"""Tester fleet battery parser coverage for Round 6 Slice A."""
+
+from __future__ import annotations
+
+import pytest
+
+from schemas.tester_fleet import HttpBatteryStep, SchemaCaptureBatteryStep
+from services.tester_fleet import BatteryParseError, load_battery_file, parse_battery_yaml
+
+
+def test_parse_battery_yaml_happy_path_preserves_step_order() -> None:
+    """Valid YAML should parse into typed steps with deterministic ordering."""
+    battery = parse_battery_yaml(
+        """
+version: 1
+service_slug: stripe
+profile: default
+steps:
+  - id: health
+    kind: http
+    method: GET
+    url: https://api.stripe.com/v1/charges?limit=1
+    expect_status: [200]
+    timeout_ms: 8000
+    retries: 1
+  - id: schema
+    kind: schema_capture
+    source_step: health
+    fingerprint: semantic_v2
+"""
+    )
+
+    assert battery.version == 1
+    assert battery.service_slug == "stripe"
+    assert [step.id for step in battery.steps] == ["health", "schema"]
+    assert isinstance(battery.steps[0], HttpBatteryStep)
+    assert isinstance(battery.steps[1], SchemaCaptureBatteryStep)
+
+
+def test_parse_battery_yaml_rejects_duplicate_step_ids() -> None:
+    """Step IDs must be unique so runner outputs remain deterministic."""
+    with pytest.raises(BatteryParseError, match="Duplicate step id"):
+        parse_battery_yaml(
+            """
+version: 1
+service_slug: stripe
+steps:
+  - id: health
+    kind: http
+    method: GET
+    url: https://api.stripe.com/v1/charges?limit=1
+  - id: health
+    kind: schema_capture
+    source_step: health
+"""
+        )
+
+
+def test_parse_battery_yaml_rejects_unknown_or_future_source_step() -> None:
+    """schema_capture/idempotency_check steps must reference an earlier step."""
+    with pytest.raises(BatteryParseError, match="unknown or future source_step"):
+        parse_battery_yaml(
+            """
+version: 1
+service_slug: stripe
+steps:
+  - id: schema
+    kind: schema_capture
+    source_step: health
+  - id: health
+    kind: http
+    method: GET
+    url: https://api.stripe.com/v1/charges?limit=1
+"""
+        )
+
+
+def test_parse_battery_yaml_rejects_invalid_step_kind() -> None:
+    """Only v0 step kinds should be accepted by the parser."""
+    with pytest.raises(BatteryParseError, match="Invalid battery definition"):
+        parse_battery_yaml(
+            """
+version: 1
+service_slug: stripe
+steps:
+  - id: weird
+    kind: graphql
+"""
+        )
+
+
+def test_parse_battery_yaml_requires_http_source_for_idempotency_check() -> None:
+    """idempotency_check currently replays HTTP request semantics only."""
+    with pytest.raises(BatteryParseError, match="requires source_step"):
+        parse_battery_yaml(
+            """
+version: 1
+service_slug: stripe
+steps:
+  - id: health
+    kind: http
+    method: GET
+    url: https://api.stripe.com/v1/charges?limit=1
+  - id: schema
+    kind: schema_capture
+    source_step: health
+  - id: replay
+    kind: idempotency_check
+    source_step: schema
+"""
+        )
+
+
+def test_load_battery_file_parses_fixture(tmp_path) -> None:
+    """File loader should delegate through parser and return a valid battery."""
+    fixture = tmp_path / "battery.yaml"
+    fixture.write_text(
+        """
+version: 1
+service_slug: stripe
+steps:
+  - id: health
+    kind: http
+    method: GET
+    url: https://api.stripe.com/v1/charges?limit=1
+""",
+        encoding="utf-8",
+    )
+
+    battery = load_battery_file(fixture)
+    assert battery.service_slug == "stripe"
+    assert len(battery.steps) == 1


### PR DESCRIPTION
## Summary
- add tester fleet battery schema models for `http`, `schema_capture`, and `idempotency_check`
- add YAML parser/loader with strict validation and typed parse errors
- add seed fixture battery for stripe health/schema checks
- add parser validation tests for happy/error paths
- add `PyYAML` dependency for battery parsing

## Validation
- `.venv/bin/black packages/api/schemas/tester_fleet.py packages/api/services/tester_fleet.py packages/api/tests/test_tester_fleet.py`
- `.venv/bin/pytest packages/api/tests/test_tester_fleet.py -q`
- `.venv/bin/pytest packages/api/tests -q`