### PR TITLE
Round 6 Slice B: single-target battery runner (http + schema_capture)

### DIFF
--- a/packages/api/schemas/tester_fleet.py
+++ b/packages/api/schemas/tester_fleet.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from datetime import datetime
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -80,3 +81,36 @@ class BatteryDefinition(BaseModel):
             raise ValueError("Battery must include at least one http step")
 
         return self
+
+
+class BatteryStepResult(BaseModel):
+    """Serialized result payload for a single executed battery step."""
+
+    id: str
+    kind: str
+    status: Literal["ok", "error"]
+    latency_ms: int | None = None
+    response_code: int | None = None
+    error: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class BatteryRunSummary(BaseModel):
+    """Aggregate execution summary for a battery run."""
+
+    success_rate: float = Field(ge=0, le=1)
+    p95_latency_ms: int | None = None
+    failures: int = Field(ge=0)
+
+
+class BatteryRunArtifact(BaseModel):
+    """Top-level runner output contract for tester fleet batteries."""
+
+    service_slug: str
+    battery_version: int
+    profile: str
+    started_at: datetime
+    completed_at: datetime
+    status: Literal["ok", "error"]
+    steps: list[BatteryStepResult]
+    summary: BatteryRunSummary

--- a/packages/api/services/tester_fleet.py
+++ b/packages/api/services/tester_fleet.py
@@ -1,18 +1,38 @@
-"""Parser utilities for tester fleet battery YAML definitions."""
+"""Parser and runner utilities for tester fleet battery YAML definitions."""
 
 from __future__ import annotations
 
+import math
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
+from time import perf_counter
 from typing import Any
 
+import httpx
 import yaml
 from pydantic import ValidationError
 
-from schemas.tester_fleet import BatteryDefinition
+from schemas.tester_fleet import (
+    BatteryDefinition,
+    BatteryRunArtifact,
+    BatteryRunSummary,
+    BatteryStepResult,
+    HttpBatteryStep,
+    SchemaCaptureBatteryStep,
+)
+from services.probes import ProbeService
 
 
 class BatteryParseError(ValueError):
     """Raised when a battery definition cannot be parsed or validated."""
+
+
+@dataclass(slots=True)
+class _StepExecutionState:
+    """Internal execution context retained for downstream dependent steps."""
+
+    schema_target: Any | None = None
 
 
 def parse_battery_yaml(raw_yaml: str) -> BatteryDefinition:
@@ -40,6 +60,215 @@ def load_battery_file(path: str | Path) -> BatteryDefinition:
         raise BatteryParseError(f"Unable to read battery file '{file_path}': {exc}") from exc
 
     return parse_battery_yaml(raw_yaml)
+
+
+class BatteryRunner:
+    """Single-target battery runner for `http` + `schema_capture` steps (Slice B)."""
+
+    def __init__(self, *, client: httpx.Client | None = None) -> None:
+        self._client = client
+
+    @staticmethod
+    def _percentile(latencies: list[int], percentile: int) -> int | None:
+        if not latencies:
+            return None
+
+        sorted_latencies = sorted(latencies)
+        rank = max(1, math.ceil((percentile / 100) * len(sorted_latencies)))
+        index = min(len(sorted_latencies) - 1, rank - 1)
+        return sorted_latencies[index]
+
+    @staticmethod
+    def _schema_target_from_response(response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except ValueError:
+            return {"text_preview": response.text[:500]}
+
+    def _run_http_step(
+        self,
+        step: HttpBatteryStep,
+        *,
+        client: httpx.Client,
+    ) -> tuple[BatteryStepResult, _StepExecutionState]:
+        last_latency_ms: int | None = None
+        max_attempts = step.retries + 1
+
+        for attempt in range(1, max_attempts + 1):
+            started = perf_counter()
+            try:
+                response = client.request(
+                    method=step.method,
+                    url=step.url,
+                    timeout=step.timeout_ms / 1000,
+                )
+            except httpx.HTTPError as exc:
+                last_latency_ms = int((perf_counter() - started) * 1000)
+                if attempt < max_attempts:
+                    continue
+
+                return (
+                    BatteryStepResult(
+                        id=step.id,
+                        kind=step.kind,
+                        status="error",
+                        latency_ms=last_latency_ms,
+                        response_code=None,
+                        error=f"HTTP request failed: {exc}",
+                        metadata={"attempts": attempt, "retries": step.retries},
+                    ),
+                    _StepExecutionState(schema_target=None),
+                )
+
+            last_latency_ms = int((perf_counter() - started) * 1000)
+            schema_target = self._schema_target_from_response(response)
+
+            if response.status_code in step.expect_status:
+                return (
+                    BatteryStepResult(
+                        id=step.id,
+                        kind=step.kind,
+                        status="ok",
+                        latency_ms=last_latency_ms,
+                        response_code=response.status_code,
+                        error=None,
+                        metadata={"attempts": attempt, "retries": step.retries},
+                    ),
+                    _StepExecutionState(schema_target=schema_target),
+                )
+
+            if attempt < max_attempts:
+                continue
+
+            return (
+                BatteryStepResult(
+                    id=step.id,
+                    kind=step.kind,
+                    status="error",
+                    latency_ms=last_latency_ms,
+                    response_code=response.status_code,
+                    error=(
+                        f"Expected status {step.expect_status}, received HTTP {response.status_code}"
+                    ),
+                    metadata={"attempts": attempt, "retries": step.retries},
+                ),
+                _StepExecutionState(schema_target=schema_target),
+            )
+
+        return (
+            BatteryStepResult(
+                id=step.id,
+                kind=step.kind,
+                status="error",
+                latency_ms=last_latency_ms,
+                response_code=None,
+                error="HTTP step failed unexpectedly",
+                metadata={"attempts": max_attempts, "retries": step.retries},
+            ),
+            _StepExecutionState(schema_target=None),
+        )
+
+    def _run_schema_capture_step(
+        self,
+        step: SchemaCaptureBatteryStep,
+        *,
+        states_by_step_id: dict[str, _StepExecutionState],
+    ) -> tuple[BatteryStepResult, _StepExecutionState]:
+        source_state = states_by_step_id.get(step.source_step)
+        if source_state is None or source_state.schema_target is None:
+            return (
+                BatteryStepResult(
+                    id=step.id,
+                    kind=step.kind,
+                    status="error",
+                    latency_ms=None,
+                    response_code=None,
+                    error=f"Source step '{step.source_step}' has no capturable payload",
+                    metadata={"source_step": step.source_step},
+                ),
+                _StepExecutionState(schema_target=None),
+            )
+
+        fingerprint, descriptor = ProbeService._schema_fingerprint(source_state.schema_target)
+
+        metadata: dict[str, Any] = {
+            "source_step": step.source_step,
+            "schema_signature_version": "v2",
+            "schema_fingerprint_v2": fingerprint,
+            "schema_descriptor": descriptor,
+        }
+
+        return (
+            BatteryStepResult(
+                id=step.id,
+                kind=step.kind,
+                status="ok",
+                latency_ms=None,
+                response_code=None,
+                error=None,
+                metadata=metadata,
+            ),
+            _StepExecutionState(schema_target=descriptor),
+        )
+
+    def run_battery(self, battery: BatteryDefinition) -> BatteryRunArtifact:
+        """Execute battery steps deterministically and return the run artifact."""
+        started_at = datetime.now(timezone.utc)
+        step_results: list[BatteryStepResult] = []
+        states_by_step_id: dict[str, _StepExecutionState] = {}
+
+        owns_client = self._client is None
+        client = self._client or httpx.Client(follow_redirects=True)
+
+        try:
+            for step in battery.steps:
+                if isinstance(step, HttpBatteryStep):
+                    step_result, state = self._run_http_step(step, client=client)
+                elif isinstance(step, SchemaCaptureBatteryStep):
+                    step_result, state = self._run_schema_capture_step(
+                        step,
+                        states_by_step_id=states_by_step_id,
+                    )
+                else:
+                    step_result = BatteryStepResult(
+                        id=step.id,
+                        kind=step.kind,
+                        status="error",
+                        latency_ms=None,
+                        response_code=None,
+                        error=(f"Step kind '{step.kind}' is not implemented in Slice B runner"),
+                        metadata=None,
+                    )
+                    state = _StepExecutionState(schema_target=None)
+
+                step_results.append(step_result)
+                states_by_step_id[step.id] = state
+        finally:
+            if owns_client:
+                client.close()
+
+        completed_at = datetime.now(timezone.utc)
+        failures = sum(1 for step in step_results if step.status != "ok")
+        latencies = [step.latency_ms for step in step_results if step.latency_ms is not None]
+        p95_latency_ms = self._percentile(latencies, 95)
+        success_rate = ((len(step_results) - failures) / len(step_results)) if step_results else 0.0
+
+        summary = BatteryRunSummary(
+            success_rate=success_rate,
+            p95_latency_ms=p95_latency_ms,
+            failures=failures,
+        )
+
+        return BatteryRunArtifact(
+            service_slug=battery.service_slug,
+            battery_version=battery.version,
+            profile=battery.profile,
+            started_at=started_at,
+            completed_at=completed_at,
+            status="ok" if failures == 0 else "error",
+            steps=step_results,
+            summary=summary,
+        )
 
 
 def _validate_payload(payload: dict[str, Any]) -> BatteryDefinition:

--- a/packages/api/tests/test_tester_fleet.py
+++ b/packages/api/tests/test_tester_fleet.py
@@ -1,11 +1,17 @@
-"""Tester fleet battery parser coverage for Round 6 Slice A."""
+"""Tester fleet battery parser and runner coverage for Round 6."""
 
 from __future__ import annotations
 
+import httpx
 import pytest
 
 from schemas.tester_fleet import HttpBatteryStep, SchemaCaptureBatteryStep
-from services.tester_fleet import BatteryParseError, load_battery_file, parse_battery_yaml
+from services.tester_fleet import (
+    BatteryParseError,
+    BatteryRunner,
+    load_battery_file,
+    parse_battery_yaml,
+)
 
 
 def test_parse_battery_yaml_happy_path_preserves_step_order() -> None:
@@ -130,3 +136,143 @@ steps:
     battery = load_battery_file(fixture)
     assert battery.service_slug == "stripe"
     assert len(battery.steps) == 1
+
+
+def test_run_battery_executes_http_and_schema_capture_steps() -> None:
+    """Slice B runner should execute HTTP then derive schema fingerprint from source payload."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert str(request.url) == "https://api.stripe.com/v1/charges?limit=1"
+        return httpx.Response(
+            status_code=200,
+            json={"object": "list", "data": [{"id": "ch_123", "amount": 1000}]},
+        )
+
+    battery = parse_battery_yaml(
+        """
+version: 1
+service_slug: stripe
+steps:
+  - id: health
+    kind: http
+    method: GET
+    url: https://api.stripe.com/v1/charges?limit=1
+    expect_status: [200]
+  - id: schema
+    kind: schema_capture
+    source_step: health
+"""
+    )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        artifact = BatteryRunner(client=client).run_battery(battery)
+
+    assert artifact.status == "ok"
+    assert artifact.service_slug == "stripe"
+    assert artifact.summary.failures == 0
+    assert artifact.summary.success_rate == 1.0
+    assert artifact.summary.p95_latency_ms is not None
+
+    assert len(artifact.steps) == 2
+    assert artifact.steps[0].status == "ok"
+    assert artifact.steps[0].response_code == 200
+
+    schema_step_metadata = artifact.steps[1].metadata or {}
+    assert artifact.steps[1].status == "ok"
+    assert schema_step_metadata["schema_signature_version"] == "v2"
+    assert schema_step_metadata["schema_fingerprint_v2"]
+
+
+def test_run_battery_marks_http_status_mismatch_as_error() -> None:
+    """HTTP steps should fail when response code is outside expect_status list."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=503, json={"error": "temporarily unavailable"})
+
+    battery = parse_battery_yaml(
+        """
+version: 1
+service_slug: stripe
+steps:
+  - id: health
+    kind: http
+    method: GET
+    url: https://api.stripe.com/v1/charges?limit=1
+    expect_status: [200]
+"""
+    )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        artifact = BatteryRunner(client=client).run_battery(battery)
+
+    assert artifact.status == "error"
+    assert artifact.summary.failures == 1
+    assert artifact.summary.success_rate == 0.0
+    assert artifact.steps[0].status == "error"
+    assert artifact.steps[0].response_code == 503
+    assert artifact.steps[0].error
+
+
+def test_run_battery_marks_schema_capture_error_when_source_payload_missing() -> None:
+    """schema_capture should fail if source HTTP step never produced payload."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("timed out")
+
+    battery = parse_battery_yaml(
+        """
+version: 1
+service_slug: stripe
+steps:
+  - id: health
+    kind: http
+    method: GET
+    url: https://api.stripe.com/v1/charges?limit=1
+    retries: 0
+  - id: schema
+    kind: schema_capture
+    source_step: health
+"""
+    )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        artifact = BatteryRunner(client=client).run_battery(battery)
+
+    assert artifact.status == "error"
+    assert artifact.summary.failures == 2
+    assert artifact.steps[0].status == "error"
+    assert artifact.steps[1].status == "error"
+    assert artifact.steps[1].error
+
+
+def test_run_battery_reports_idempotency_step_as_not_implemented_in_slice_b() -> None:
+    """Slice B runner should surface clear error for not-yet-implemented idempotency steps."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=200, json={"ok": True})
+
+    battery = parse_battery_yaml(
+        """
+version: 1
+service_slug: stripe
+steps:
+  - id: health
+    kind: http
+    method: GET
+    url: https://api.stripe.com/v1/charges?limit=1
+  - id: replay
+    kind: idempotency_check
+    source_step: health
+"""
+    )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        artifact = BatteryRunner(client=client).run_battery(battery)
+
+    assert artifact.status == "error"
+    assert artifact.summary.failures == 1
+    assert artifact.steps[0].status == "ok"
+    assert artifact.steps[1].status == "error"
+    assert artifact.steps[1].error
+    assert "not implemented" in artifact.steps[1].error


### PR DESCRIPTION
## Summary
- add Slice B tester-fleet runner harness (`BatteryRunner`) for deterministic single-target execution
- execute `http` steps with timeout/retry handling and status validation
- execute `schema_capture` steps by reusing probe semantic fingerprinting (`schema_fingerprint_v2`)
- emit typed runner artifact contract (`BatteryRunArtifact`, step results, summary)
- add runner happy/error tests and unsupported-step guard for future `idempotency_check`

## Validation
- `.venv/bin/black packages/api/schemas/tester_fleet.py packages/api/services/tester_fleet.py packages/api/tests/test_tester_fleet.py`
- `.venv/bin/pytest packages/api/tests/test_tester_fleet.py -q`
- `.venv/bin/pytest packages/api/tests -q`