### PR TITLE
Round 6 Slice C: artifact writer + probe metadata bridge

### DIFF
--- a/packages/api/services/tester_fleet.py
+++ b/packages/api/services/tester_fleet.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -13,6 +14,7 @@ import httpx
 import yaml
 from pydantic import ValidationError
 
+from db.repository import ProbeRepository, StoredProbe
 from schemas.tester_fleet import (
     BatteryDefinition,
     BatteryRunArtifact,
@@ -269,6 +271,173 @@ class BatteryRunner:
             steps=step_results,
             summary=summary,
         )
+
+
+class BatteryArtifactWriter:
+    """Persist battery run artifacts as JSON documents on disk."""
+
+    def __init__(self, output_dir: str | Path) -> None:
+        self._output_dir = Path(output_dir)
+
+    @staticmethod
+    def _filename_for(artifact: BatteryRunArtifact) -> str:
+        stamp = artifact.completed_at.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        return (
+            f"{artifact.service_slug}-{artifact.profile}-v{artifact.battery_version}-{stamp}.json"
+        )
+
+    def write(self, artifact: BatteryRunArtifact) -> Path:
+        """Write a battery artifact JSON file and return the absolute path."""
+        self._output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = self._output_dir / self._filename_for(artifact)
+        payload = artifact.model_dump(mode="json")
+        output_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        return output_path.resolve()
+
+
+class BatteryProbeBridge:
+    """Translate battery artifacts into probe-compatible metadata and records."""
+
+    def __init__(self, repository: ProbeRepository) -> None:
+        self._repository = repository
+
+    @staticmethod
+    def _http_steps(artifact: BatteryRunArtifact) -> list[BatteryStepResult]:
+        return [step for step in artifact.steps if step.kind == "http"]
+
+    @staticmethod
+    def _schema_step(artifact: BatteryRunArtifact) -> BatteryStepResult | None:
+        for step in artifact.steps:
+            if step.kind == "schema_capture":
+                return step
+        return None
+
+    @classmethod
+    def _latency_distribution(cls, artifact: BatteryRunArtifact) -> dict[str, int] | None:
+        latencies = [
+            step.latency_ms for step in cls._http_steps(artifact) if step.latency_ms is not None
+        ]
+        if not latencies:
+            return None
+
+        p50 = BatteryRunner._percentile(latencies, 50)
+        p95 = BatteryRunner._percentile(latencies, 95)
+        p99 = BatteryRunner._percentile(latencies, 99)
+
+        if p50 is None or p95 is None or p99 is None:
+            return None
+
+        return {
+            "p50": p50,
+            "p95": p95,
+            "p99": p99,
+            "samples": len(latencies),
+        }
+
+    @classmethod
+    def build_probe_metadata(
+        cls,
+        artifact: BatteryRunArtifact,
+        *,
+        artifact_path: str | Path | None = None,
+    ) -> dict[str, Any]:
+        """Build a probe metadata payload that nests tester-fleet details."""
+        step_status = {step.id: step.status for step in artifact.steps}
+        tester_fleet_metadata: dict[str, Any] = {
+            "battery_version": artifact.battery_version,
+            "profile": artifact.profile,
+            "status": artifact.status,
+            "summary": artifact.summary.model_dump(mode="json"),
+            "step_status": step_status,
+        }
+        if artifact_path is not None:
+            tester_fleet_metadata["artifact_path"] = str(Path(artifact_path))
+
+        metadata: dict[str, Any] = {
+            "runner": "tester-fleet-v0",
+            "service_slug": artifact.service_slug,
+            "tester_fleet": tester_fleet_metadata,
+        }
+
+        latency_distribution = cls._latency_distribution(artifact)
+        if latency_distribution is not None:
+            metadata["latency_distribution_ms"] = latency_distribution
+
+        schema_step = cls._schema_step(artifact)
+        schema_metadata = schema_step.metadata if schema_step else None
+        if isinstance(schema_metadata, dict):
+            schema_fingerprint = schema_metadata.get("schema_fingerprint_v2")
+            if isinstance(schema_fingerprint, str) and schema_fingerprint:
+                metadata["schema_signature_version"] = schema_metadata.get(
+                    "schema_signature_version", "v2"
+                )
+                metadata["schema_fingerprint_v2"] = schema_fingerprint
+                metadata["schema_descriptor"] = schema_metadata.get("schema_descriptor")
+
+        return metadata
+
+    def persist(
+        self,
+        artifact: BatteryRunArtifact,
+        *,
+        artifact_path: str | Path | None = None,
+        trigger_source: str = "tester_fleet",
+    ) -> list[StoredProbe]:
+        """Persist bridge probe records (`health` + optional `schema`) for an artifact."""
+        probe_metadata = self.build_probe_metadata(artifact, artifact_path=artifact_path)
+
+        persisted: list[StoredProbe] = []
+        http_steps = self._http_steps(artifact)
+        http_latencies = [step.latency_ms for step in http_steps if step.latency_ms is not None]
+        latest_http = http_steps[-1] if http_steps else None
+        health_error = next((step.error for step in http_steps if step.status != "ok"), None)
+
+        if latest_http is not None:
+            persisted.append(
+                self._repository.save_probe(
+                    service_slug=artifact.service_slug,
+                    probe_type="health",
+                    status="ok" if all(step.status == "ok" for step in http_steps) else "error",
+                    latency_ms=BatteryRunner._percentile(http_latencies, 50),
+                    response_code=latest_http.response_code,
+                    response_schema_hash=None,
+                    raw_response={
+                        "tester_fleet": {
+                            "artifact_status": artifact.status,
+                            "summary": artifact.summary.model_dump(mode="json"),
+                        }
+                    },
+                    probe_metadata=probe_metadata,
+                    trigger_source=trigger_source,
+                    runner_version="tester-fleet-v0",
+                    error_message=health_error,
+                )
+            )
+
+        schema_step = self._schema_step(artifact)
+        if schema_step is not None:
+            schema_metadata = schema_step.metadata or {}
+            schema_fingerprint = schema_metadata.get("schema_fingerprint_v2")
+            response_schema_hash = (
+                schema_fingerprint if isinstance(schema_fingerprint, str) else None
+            )
+            persisted.append(
+                self._repository.save_probe(
+                    service_slug=artifact.service_slug,
+                    probe_type="schema",
+                    status=schema_step.status,
+                    latency_ms=None,
+                    response_code=None,
+                    response_schema_hash=response_schema_hash,
+                    raw_response={"tester_fleet_schema_step": schema_step.model_dump(mode="json")},
+                    probe_metadata=probe_metadata,
+                    trigger_source=trigger_source,
+                    runner_version="tester-fleet-v0",
+                    error_message=schema_step.error,
+                )
+            )
+
+        return persisted
 
 
 def _validate_payload(payload: dict[str, Any]) -> BatteryDefinition:

--- a/packages/api/tests/test_tester_fleet.py
+++ b/packages/api/tests/test_tester_fleet.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 
+from db.repository import InMemoryProbeRepository
 from schemas.tester_fleet import HttpBatteryStep, SchemaCaptureBatteryStep
 from services.tester_fleet import (
+    BatteryArtifactWriter,
     BatteryParseError,
+    BatteryProbeBridge,
     BatteryRunner,
     load_battery_file,
     parse_battery_yaml,
@@ -276,3 +281,127 @@ steps:
     assert artifact.steps[1].status == "error"
     assert artifact.steps[1].error
     assert "not implemented" in artifact.steps[1].error
+
+
+def test_slice_c_artifact_writer_persists_json_artifact(tmp_path) -> None:
+    """Slice C writer should persist a deterministic JSON artifact to disk."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=200, json={"ok": True, "service": "stripe"})
+
+    battery = parse_battery_yaml(
+        """
+version: 1
+service_slug: stripe
+profile: smoke
+steps:
+  - id: health
+    kind: http
+    method: GET
+    url: https://api.stripe.com/v1/charges?limit=1
+  - id: schema
+    kind: schema_capture
+    source_step: health
+"""
+    )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        artifact = BatteryRunner(client=client).run_battery(battery)
+
+    writer = BatteryArtifactWriter(output_dir=tmp_path / "artifacts")
+    artifact_path = writer.write(artifact)
+
+    assert artifact_path.exists()
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert payload["service_slug"] == "stripe"
+    assert payload["profile"] == "smoke"
+    assert payload["summary"]["failures"] == 0
+
+
+def test_slice_c_probe_bridge_builds_tester_fleet_metadata(tmp_path) -> None:
+    """Bridge metadata should include tester_fleet payload + probe-compatible keys."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=200, json={"object": "list", "data": [{"id": "x"}]})
+
+    battery = parse_battery_yaml(
+        """
+version: 1
+service_slug: stripe
+steps:
+  - id: health
+    kind: http
+    method: GET
+    url: https://api.stripe.com/v1/charges?limit=1
+  - id: schema
+    kind: schema_capture
+    source_step: health
+"""
+    )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        artifact = BatteryRunner(client=client).run_battery(battery)
+
+    metadata = BatteryProbeBridge.build_probe_metadata(
+        artifact,
+        artifact_path=tmp_path / "artifacts" / "stripe.json",
+    )
+
+    assert metadata["runner"] == "tester-fleet-v0"
+    assert metadata["service_slug"] == "stripe"
+    assert metadata["tester_fleet"]["status"] == "ok"
+    assert metadata["tester_fleet"]["artifact_path"].endswith("stripe.json")
+    assert metadata["latency_distribution_ms"]["samples"] == 1
+    assert metadata["schema_signature_version"] == "v2"
+    assert metadata["schema_fingerprint_v2"]
+
+
+def test_slice_c_probe_bridge_persists_health_and_schema_records(tmp_path) -> None:
+    """Bridge persistence should write health + schema probe rows with tester_fleet metadata."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=200, json={"ok": True, "nested": {"value": 1}})
+
+    battery = parse_battery_yaml(
+        """
+version: 1
+service_slug: stripe
+steps:
+  - id: health
+    kind: http
+    method: GET
+    url: https://api.stripe.com/v1/charges?limit=1
+  - id: schema
+    kind: schema_capture
+    source_step: health
+"""
+    )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        artifact = BatteryRunner(client=client).run_battery(battery)
+
+    writer = BatteryArtifactWriter(output_dir=tmp_path / "artifacts")
+    artifact_path = writer.write(artifact)
+
+    repository = InMemoryProbeRepository()
+    persisted = BatteryProbeBridge(repository).persist(
+        artifact,
+        artifact_path=artifact_path,
+        trigger_source="tester-fleet-test",
+    )
+
+    assert len(persisted) == 2
+    probe_types = {probe.probe_type for probe in persisted}
+    assert probe_types == {"health", "schema"}
+
+    latest_health = repository.fetch_latest_probe("stripe", probe_type="health")
+    latest_schema = repository.fetch_latest_probe("stripe", probe_type="schema")
+
+    assert latest_health is not None
+    assert latest_schema is not None
+    assert latest_health.trigger_source == "tester-fleet-test"
+    assert latest_health.probe_metadata is not None
+    assert latest_health.probe_metadata["tester_fleet"]["summary"]["failures"] == 0
+    assert (
+        latest_schema.response_schema_hash == latest_schema.probe_metadata["schema_fingerprint_v2"]
+    )


### PR DESCRIPTION
## Summary
- add `BatteryArtifactWriter` to persist battery run artifacts as deterministic JSON files
- add `BatteryProbeBridge` to translate battery artifacts into probe-compatible metadata under `probe_metadata.tester_fleet`
- bridge tester-fleet outputs into persisted `health` + `schema` probe records with latency/schema signals exposed at top-level metadata
- add Slice C tests for artifact persistence, metadata shape, and probe repository integration

## Validation
- `.venv/bin/black packages/api/services/tester_fleet.py packages/api/tests/test_tester_fleet.py`
- `.venv/bin/pytest packages/api/tests/test_tester_fleet.py -q`
- `.venv/bin/pytest packages/api/tests -q`