### PR TITLE
Round 6 Slice D: rhumb test-battery CLI + API run route

### DIFF
--- a/packages/api/app.py
+++ b/packages/api/app.py
@@ -2,7 +2,7 @@
 
 from fastapi import FastAPI
 
-from routes import leaderboard, probes, scores, search, services
+from routes import leaderboard, probes, scores, search, services, tester_fleet
 
 
 def create_app() -> FastAPI:
@@ -13,6 +13,7 @@ def create_app() -> FastAPI:
     application.include_router(scores.router, prefix="/v1", tags=["scores"])
     application.include_router(search.router, prefix="/v1", tags=["search"])
     application.include_router(leaderboard.router, prefix="/v1", tags=["leaderboard"])
+    application.include_router(tester_fleet.router, prefix="/v1", tags=["tester-fleet"])
 
     @application.get("/healthz")
     async def healthz() -> dict[str, str]:

--- a/packages/api/routes/tester_fleet.py
+++ b/packages/api/routes/tester_fleet.py
@@ -1,0 +1,106 @@
+"""Tester fleet execution routes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+
+from routes.probes import get_probe_service
+from schemas.tester_fleet import BatteryRunRequestSchema, BatteryRunResponseSchema
+from services.tester_fleet import (
+    BatteryArtifactWriter,
+    BatteryParseError,
+    BatteryProbeBridge,
+    BatteryRunner,
+    load_battery_file,
+)
+
+router = APIRouter()
+
+
+def _batteries_dir() -> Path:
+    return Path(__file__).resolve().parent.parent / "batteries"
+
+
+def _artifacts_dir() -> Path:
+    return Path(__file__).resolve().parent.parent / "artifacts" / "tester_fleet"
+
+
+def _resolve_battery_file(service_slug: str, profile: str) -> Path | None:
+    base_dir = _batteries_dir()
+    candidates: list[str] = []
+
+    normalized_profile = profile.strip().lower()
+    if normalized_profile and normalized_profile != "default":
+        candidates.append(f"{service_slug}-{normalized_profile}.yaml")
+
+    candidates.extend(
+        [
+            f"{service_slug}-health.yaml",
+            f"{service_slug}.yaml",
+        ]
+    )
+
+    for candidate in candidates:
+        path = base_dir / candidate
+        if path.exists():
+            return path
+
+    return None
+
+
+@router.post("/tester-fleet/run", response_model=BatteryRunResponseSchema)
+async def run_tester_fleet_battery(payload: BatteryRunRequestSchema) -> BatteryRunResponseSchema:
+    """Run a seeded tester-fleet battery for one service and persist evidence."""
+    battery_file = _resolve_battery_file(payload.service_slug, payload.profile)
+    if battery_file is None:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"No battery found for service '{payload.service_slug}' "
+                f"(profile '{payload.profile}')"
+            ),
+        )
+
+    try:
+        battery = load_battery_file(battery_file)
+    except BatteryParseError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if battery.service_slug != payload.service_slug:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Battery service mismatch: requested '{payload.service_slug}', "
+                f"battery defines '{battery.service_slug}'"
+            ),
+        )
+
+    artifact = BatteryRunner().run_battery(battery)
+    artifact_writer = BatteryArtifactWriter(output_dir=_artifacts_dir())
+    artifact_path = artifact_writer.write(artifact)
+
+    persisted_probe_ids: list[str] = []
+    persisted_probe_types: list[str] = []
+
+    if payload.persist_probes:
+        probe_service = get_probe_service()
+        probe_repository = probe_service.repository
+        if probe_repository is not None:
+            persisted = BatteryProbeBridge(probe_repository).persist(
+                artifact,
+                artifact_path=artifact_path,
+                trigger_source=payload.trigger_source,
+            )
+            persisted_probe_ids = [str(probe.id) for probe in persisted]
+            persisted_probe_types = [probe.probe_type for probe in persisted]
+
+    return BatteryRunResponseSchema(
+        service_slug=payload.service_slug,
+        battery_file=str(battery_file),
+        artifact_path=str(artifact_path),
+        run=artifact,
+        persisted_probe_ids=persisted_probe_ids,
+        persisted_probe_types=persisted_probe_types,
+    )

--- a/packages/api/schemas/tester_fleet.py
+++ b/packages/api/schemas/tester_fleet.py
@@ -114,3 +114,23 @@ class BatteryRunArtifact(BaseModel):
     status: Literal["ok", "error"]
     steps: list[BatteryStepResult]
     summary: BatteryRunSummary
+
+
+class BatteryRunRequestSchema(BaseModel):
+    """Input payload for POST /v1/tester-fleet/run."""
+
+    service_slug: str = Field(min_length=1)
+    profile: str = Field(default="default", min_length=1)
+    persist_probes: bool = True
+    trigger_source: str = Field(default="tester_fleet_cli", min_length=1)
+
+
+class BatteryRunResponseSchema(BaseModel):
+    """Serialized tester-fleet run + persistence envelope."""
+
+    service_slug: str
+    battery_file: str
+    artifact_path: str
+    run: BatteryRunArtifact
+    persisted_probe_ids: list[str]
+    persisted_probe_types: list[str]

--- a/packages/api/services/probes.py
+++ b/packages/api/services/probes.py
@@ -327,6 +327,11 @@ class ProbeService:
             error_message=execution.error_message,
         )
 
+    @property
+    def repository(self) -> ProbeRepository | None:
+        """Expose the configured repository for bridge integrations."""
+        return self._repository
+
     def fetch_latest_probe(
         self, service_slug: str, probe_type: str | None = None
     ) -> StoredProbe | None:

--- a/packages/api/tests/test_tester_fleet_routes.py
+++ b/packages/api/tests/test_tester_fleet_routes.py
@@ -1,0 +1,175 @@
+"""Tester fleet route coverage for Slice D CLI/API integration."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from db.repository import InMemoryProbeRepository
+from schemas.tester_fleet import BatteryRunArtifact, BatteryRunSummary, BatteryStepResult
+from services.probes import ProbeService
+
+
+def _seed_battery_file(path: Path, *, service_slug: str = "stripe") -> None:
+    path.write_text(
+        f"""
+version: 1
+service_slug: {service_slug}
+steps:
+  - id: health
+    kind: http
+    method: GET
+    url: https://example.com/health
+  - id: schema
+    kind: schema_capture
+    source_step: health
+""",
+        encoding="utf-8",
+    )
+
+
+def _stub_artifact(service_slug: str = "stripe") -> BatteryRunArtifact:
+    now = datetime.now(timezone.utc)
+    return BatteryRunArtifact(
+        service_slug=service_slug,
+        battery_version=1,
+        profile="default",
+        started_at=now,
+        completed_at=now,
+        status="ok",
+        steps=[
+            BatteryStepResult(
+                id="health",
+                kind="http",
+                status="ok",
+                latency_ms=42,
+                response_code=200,
+                metadata={"attempts": 1, "retries": 0},
+            ),
+            BatteryStepResult(
+                id="schema",
+                kind="schema_capture",
+                status="ok",
+                metadata={
+                    "source_step": "health",
+                    "schema_signature_version": "v2",
+                    "schema_fingerprint_v2": "deadbeef",
+                    "schema_descriptor": {"type": "object", "keys": ["ok"]},
+                },
+            ),
+        ],
+        summary=BatteryRunSummary(success_rate=1.0, p95_latency_ms=42, failures=0),
+    )
+
+
+def test_run_tester_fleet_battery_returns_404_when_missing(client) -> None:
+    """Route should return 404 when no seeded battery exists for requested service/profile."""
+    response = client.post(
+        "/v1/tester-fleet/run",
+        json={"service_slug": "does-not-exist", "profile": "default"},
+    )
+
+    assert response.status_code == 404
+    assert "No battery found" in response.json()["detail"]
+
+
+def test_run_tester_fleet_battery_runs_and_persists_probe_bridge(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Route should run battery, write artifact, and persist health/schema probe rows."""
+    from routes import tester_fleet as tester_fleet_routes
+
+    battery_file = tmp_path / "stripe-health.yaml"
+    _seed_battery_file(battery_file)
+
+    class StubRunner:
+        def run_battery(self, battery):
+            return _stub_artifact(service_slug=battery.service_slug)
+
+    repository = InMemoryProbeRepository()
+    probe_service = ProbeService(repository=repository)
+
+    monkeypatch.setattr(
+        tester_fleet_routes,
+        "_resolve_battery_file",
+        lambda service_slug, profile: battery_file,
+    )
+    monkeypatch.setattr(tester_fleet_routes, "_artifacts_dir", lambda: tmp_path / "artifacts")
+    monkeypatch.setattr(tester_fleet_routes, "BatteryRunner", StubRunner)
+    monkeypatch.setattr(tester_fleet_routes, "get_probe_service", lambda: probe_service)
+
+    response = client.post(
+        "/v1/tester-fleet/run",
+        json={
+            "service_slug": "stripe",
+            "profile": "default",
+            "persist_probes": True,
+            "trigger_source": "tester-fleet-route-test",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["service_slug"] == "stripe"
+    assert body["run"]["status"] == "ok"
+    assert body["run"]["summary"]["failures"] == 0
+    assert Path(body["artifact_path"]).exists()
+    assert sorted(body["persisted_probe_types"]) == ["health", "schema"]
+    assert len(body["persisted_probe_ids"]) == 2
+
+    latest_health = repository.fetch_latest_probe("stripe", probe_type="health")
+    latest_schema = repository.fetch_latest_probe("stripe", probe_type="schema")
+
+    assert latest_health is not None
+    assert latest_schema is not None
+    assert latest_health.trigger_source == "tester-fleet-route-test"
+    assert latest_schema.probe_metadata is not None
+    assert latest_schema.probe_metadata["tester_fleet"]["summary"]["failures"] == 0
+
+
+def test_run_tester_fleet_battery_supports_no_persist(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Route should skip probe persistence when persist_probes=false."""
+    from routes import tester_fleet as tester_fleet_routes
+
+    battery_file = tmp_path / "stripe-health.yaml"
+    _seed_battery_file(battery_file)
+
+    class StubRunner:
+        def run_battery(self, battery):
+            return _stub_artifact(service_slug=battery.service_slug)
+
+    repository = InMemoryProbeRepository()
+    probe_service = ProbeService(repository=repository)
+
+    monkeypatch.setattr(
+        tester_fleet_routes,
+        "_resolve_battery_file",
+        lambda service_slug, profile: battery_file,
+    )
+    monkeypatch.setattr(tester_fleet_routes, "_artifacts_dir", lambda: tmp_path / "artifacts")
+    monkeypatch.setattr(tester_fleet_routes, "BatteryRunner", StubRunner)
+    monkeypatch.setattr(tester_fleet_routes, "get_probe_service", lambda: probe_service)
+
+    response = client.post(
+        "/v1/tester-fleet/run",
+        json={
+            "service_slug": "stripe",
+            "profile": "default",
+            "persist_probes": False,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["persisted_probe_ids"] == []
+    assert body["persisted_probe_types"] == []
+    assert repository.fetch_latest_probe("stripe", probe_type="health") is None

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,6 +18,8 @@ rhumb score stripe --mode access --dimensions
 rhumb score stripe --json
 rhumb find "payment routing"
 rhumb find "payment routing" --limit 5 --json
+rhumb test-battery stripe
+rhumb test-battery stripe --no-persist-probes
 ```
 
 `rhumb score` supports v0.2 dual-score output:

--- a/packages/cli/commands/tester_fleet.py
+++ b/packages/cli/commands/tester_fleet.py
@@ -1,0 +1,90 @@
+"""`rhumb test-battery` command."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import typer
+
+from client import RhumbAPIClient
+from formatting import render_output
+
+
+def _render_human(payload: dict[str, Any], service: str) -> str:
+    run = payload.get("run") if isinstance(payload.get("run"), dict) else {}
+    summary = run.get("summary") if isinstance(run.get("summary"), dict) else {}
+
+    display_service = str(payload.get("service_slug") or service)
+    status = str(run.get("status") or "unknown")
+    failures = int(summary.get("failures", 0))
+    success_rate = float(summary.get("success_rate", 0.0))
+    p95_latency_ms = summary.get("p95_latency_ms")
+    artifact_path = str(payload.get("artifact_path", ""))
+
+    persisted_probe_types = payload.get("persisted_probe_types", [])
+    if not isinstance(persisted_probe_types, list):
+        persisted_probe_types = []
+
+    latency_text = f"{int(p95_latency_ms)} ms" if p95_latency_ms is not None else "N/A"
+    probes_text = ", ".join(str(item) for item in persisted_probe_types) or "none"
+
+    lines = [
+        f"━━━ Tester Fleet: {display_service} ━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+        "",
+        f"  Status: {status}",
+        f"  Success Rate: {success_rate:.2f}",
+        f"  Failures: {failures}",
+        f"  P95 Latency: {latency_text}",
+        f"  Persisted Probes: {probes_text}",
+    ]
+
+    if artifact_path:
+        lines.append(f"  Artifact: {artifact_path}")
+
+    return "\n".join(lines)
+
+
+def test_battery(
+    service: str,
+    profile: str = typer.Option("default", "--profile", help="Battery profile name."),
+    persist_probes: bool = typer.Option(
+        True,
+        "--persist-probes/--no-persist-probes",
+        help="Persist run outputs into probe storage metadata.",
+    ),
+    trigger_source: str = typer.Option(
+        "tester_fleet_cli",
+        "--trigger-source",
+        help="Trigger source label for persisted probe rows.",
+    ),
+    as_json: bool = typer.Option(False, "--json", help="Return raw JSON payload."),
+) -> None:
+    """Run a seeded tester-fleet battery for one service."""
+    client = RhumbAPIClient()
+
+    try:
+        payload = client.post(
+            "/tester-fleet/run",
+            json={
+                "service_slug": service,
+                "profile": profile,
+                "persist_probes": persist_probes,
+                "trigger_source": trigger_source,
+            },
+        )
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            typer.echo(f"No battery found for '{service}' (profile '{profile}').")
+            raise typer.Exit(code=1) from exc
+        typer.echo(f"API error: {exc}")
+        raise typer.Exit(code=1) from exc
+    except httpx.HTTPError as exc:
+        typer.echo(f"API error: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if as_json:
+        typer.echo(render_output(payload, as_json=True))
+        return
+
+    typer.echo(_render_human(payload, service=service))

--- a/packages/cli/main.py
+++ b/packages/cli/main.py
@@ -2,7 +2,18 @@
 
 import typer
 
-from commands import bench, chart, compare, evaluate, failures, find, leaderboard, score, watch
+from commands import (
+    bench,
+    chart,
+    compare,
+    evaluate,
+    failures,
+    find,
+    leaderboard,
+    score,
+    tester_fleet,
+    watch,
+)
 
 app = typer.Typer(help="Rhumb: Agent-native tool discovery and scoring")
 
@@ -15,6 +26,7 @@ app.command()(failures.failures)
 app.command()(bench.bench)
 app.command()(watch.watch)
 app.command()(evaluate.evaluate)
+app.command()(tester_fleet.test_battery)
 
 if __name__ == "__main__":
     app()

--- a/packages/cli/tests/test_commands.py
+++ b/packages/cli/tests/test_commands.py
@@ -259,3 +259,74 @@ def test_find_command_no_results(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result.exit_code == 0
     assert "Results: 0" in result.stdout
     assert "No matching services found." in result.stdout
+
+
+def _sample_test_battery_payload() -> dict[str, Any]:
+    return {
+        "service_slug": "stripe",
+        "battery_file": "/tmp/batteries/stripe-health.yaml",
+        "artifact_path": "/tmp/artifacts/stripe-default-v1-20260305T123700000000Z.json",
+        "run": {
+            "service_slug": "stripe",
+            "battery_version": 1,
+            "profile": "default",
+            "started_at": "2026-03-05T20:36:00+00:00",
+            "completed_at": "2026-03-05T20:36:00+00:00",
+            "status": "ok",
+            "steps": [
+                {
+                    "id": "health",
+                    "kind": "http",
+                    "status": "ok",
+                    "latency_ms": 42,
+                    "response_code": 200,
+                    "error": None,
+                    "metadata": {"attempts": 1, "retries": 0},
+                }
+            ],
+            "summary": {
+                "success_rate": 1.0,
+                "p95_latency_ms": 42,
+                "failures": 0,
+            },
+        },
+        "persisted_probe_ids": ["a", "b"],
+        "persisted_probe_types": ["health", "schema"],
+    }
+
+
+def test_test_battery_command_human_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """test-battery command should render summary output in human mode."""
+
+    def fake_post(self: RhumbAPIClient, path: str, json: dict[str, Any]) -> dict[str, Any]:
+        assert path == "/tester-fleet/run"
+        assert json["service_slug"] == "stripe"
+        assert json["profile"] == "default"
+        assert json["persist_probes"] is True
+        return _sample_test_battery_payload()
+
+    monkeypatch.setattr(RhumbAPIClient, "post", fake_post)
+    result = runner.invoke(app, ["test-battery", "stripe"])
+
+    assert result.exit_code == 0
+    assert "Tester Fleet: stripe" in result.stdout
+    assert "Status: ok" in result.stdout
+    assert "Failures: 0" in result.stdout
+    assert "Persisted Probes: health, schema" in result.stdout
+
+
+def test_test_battery_command_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """test-battery command should support --json passthrough."""
+
+    def fake_post(self: RhumbAPIClient, path: str, json: dict[str, Any]) -> dict[str, Any]:
+        assert path == "/tester-fleet/run"
+        assert json["service_slug"] == "stripe"
+        assert json["persist_probes"] is False
+        return _sample_test_battery_payload()
+
+    monkeypatch.setattr(RhumbAPIClient, "post", fake_post)
+    result = runner.invoke(app, ["test-battery", "stripe", "--no-persist-probes", "--json"])
+
+    assert result.exit_code == 0
+    assert '"service_slug": "stripe"' in result.stdout
+    assert '"persisted_probe_types": [' in result.stdout


### PR DESCRIPTION
## Summary
- add `POST /v1/tester-fleet/run` route to execute seeded batteries, persist artifacts, and bridge into probe records
- register tester-fleet router in API app and extend tester-fleet schemas with request/response envelopes
- expose `ProbeService.repository` for bridge-safe persistence access
- add `rhumb test-battery <service>` CLI command with `--profile`, `--persist-probes/--no-persist-probes`, and `--json`
- add API + CLI tests for route behavior, persistence toggles, and command rendering

## Validation
- `cd packages/api && ../../.venv/bin/pytest tests -q`
- `cd packages/cli && ../../.venv/bin/pytest tests -q`