### PR TITLE
Round 7 Slice A: web contracts and route scaffold

### DIFF
--- a/packages/web/app/leaderboard/[category]/page.tsx
+++ b/packages/web/app/leaderboard/[category]/page.tsx
@@ -1,14 +1,20 @@
+import React from "react";
+
+import { getLeaderboard } from "../../../lib/api";
+
 export default async function LeaderboardPage({
-  params,
+  params
 }: {
   params: Promise<{ category: string }>;
 }): Promise<JSX.Element> {
   const { category } = await params;
+  const leaderboard = await getLeaderboard(category);
 
   return (
     <section>
-      <h1>{category} leaderboard</h1>
-      <p>Category rankings scaffold.</p>
+      <h1>{leaderboard.category} leaderboard</h1>
+      <p>Round 7 Slice A scaffold.</p>
+      <p>Entries loaded: {leaderboard.items.length}</p>
     </section>
   );
 }

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Link from "next/link";
 
 export default function HomePage(): JSX.Element {
@@ -5,7 +6,14 @@ export default function HomePage(): JSX.Element {
     <section>
       <h1>Rhumb</h1>
       <p>Agent-native tool discovery and scoring.</p>
-      <Link href="/services">Browse services</Link>
+      <ul style={{ display: "grid", gap: 8, marginTop: 16 }}>
+        <li>
+          <Link href="/leaderboard/payments">View payments leaderboard</Link>
+        </li>
+        <li>
+          <Link href="/service/stripe">View service scaffold (stripe)</Link>
+        </li>
+      </ul>
     </section>
   );
 }

--- a/packages/web/app/service/[slug]/page.tsx
+++ b/packages/web/app/service/[slug]/page.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import { getServiceScore } from "../../../lib/api";
+
+export default async function ServicePage({
+  params
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<JSX.Element> {
+  const { slug } = await params;
+  const score = await getServiceScore(slug);
+
+  return (
+    <section>
+      <h1>Service: {slug}</h1>
+      <p>Round 7 Slice A scaffold.</p>
+      <p>
+        Aggregate recommendation score: {score?.aggregateRecommendationScore ?? "pending"}
+      </p>
+    </section>
+  );
+}

--- a/packages/web/lib/adapters.ts
+++ b/packages/web/lib/adapters.ts
@@ -1,0 +1,95 @@
+import type { LeaderboardItem, LeaderboardViewModel, Service, ServiceScoreViewModel } from "./types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asItems(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is Record<string, unknown> => isRecord(item));
+}
+
+export function parseServicesResponse(payload: unknown): Service[] {
+  if (!isRecord(payload) || !isRecord(payload.data)) {
+    return [];
+  }
+
+  return asItems(payload.data.items)
+    .map((item) => {
+      const slug = asString(item.slug);
+      const name = asString(item.name);
+      const category = asString(item.category);
+      if (!slug || !name || !category) {
+        return null;
+      }
+
+      const description = asString(item.description);
+      return {
+        slug,
+        name,
+        category,
+        ...(description ? { description } : {})
+      };
+    })
+    .filter((service): service is Service => service !== null);
+}
+
+function parseLeaderboardItem(item: Record<string, unknown>): LeaderboardItem | null {
+  const serviceSlug = asString(item.service_slug);
+  if (!serviceSlug) {
+    return null;
+  }
+
+  return {
+    serviceSlug,
+    name: asString(item.name) ?? serviceSlug,
+    aggregateRecommendationScore: asNumber(item.aggregate_recommendation_score),
+    tier: asString(item.tier),
+    confidence: asNumber(item.confidence)
+  };
+}
+
+export function parseLeaderboardResponse(payload: unknown): LeaderboardViewModel {
+  if (!isRecord(payload) || !isRecord(payload.data)) {
+    return { category: "unknown", items: [] };
+  }
+
+  const category = asString(payload.data.category) ?? "unknown";
+  const items = asItems(payload.data.items)
+    .map((item) => parseLeaderboardItem(item))
+    .filter((item): item is LeaderboardItem => item !== null);
+
+  return { category, items };
+}
+
+export function parseServiceScoreResponse(payload: unknown): ServiceScoreViewModel | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const serviceSlug = asString(payload.service_slug);
+  if (!serviceSlug) {
+    return null;
+  }
+
+  return {
+    serviceSlug,
+    aggregateRecommendationScore: asNumber(payload.aggregate_recommendation_score),
+    executionScore: asNumber(payload.execution_score),
+    accessReadinessScore: asNumber(payload.access_readiness_score),
+    confidence: asNumber(payload.confidence),
+    tier: asString(payload.tier),
+    explanation: asString(payload.explanation)
+  };
+}

--- a/packages/web/lib/api.ts
+++ b/packages/web/lib/api.ts
@@ -1,13 +1,31 @@
-import type { Service } from "./types";
+import { parseLeaderboardResponse, parseServiceScoreResponse, parseServicesResponse } from "./adapters";
+import type { LeaderboardViewModel, Service, ServiceScoreViewModel } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/v1";
 
+async function fetchPayload(path: string): Promise<unknown> {
+  const response = await fetch(`${API_BASE}${path}`, { cache: "no-store" });
+  if (!response.ok) {
+    return null;
+  }
+
+  return (await response.json()) as unknown;
+}
+
 /** Fetch all services. */
 export async function getServices(): Promise<Service[]> {
-  const response = await fetch(`${API_BASE}/services`, { cache: "no-store" });
-  if (!response.ok) {
-    return [];
-  }
-  const payload = (await response.json()) as { data?: { items?: Service[] } };
-  return payload.data?.items ?? [];
+  const payload = await fetchPayload("/services");
+  return parseServicesResponse(payload);
+}
+
+/** Fetch category leaderboard. */
+export async function getLeaderboard(category: string): Promise<LeaderboardViewModel> {
+  const payload = await fetchPayload(`/leaderboard/${encodeURIComponent(category)}`);
+  return parseLeaderboardResponse(payload);
+}
+
+/** Fetch latest score details for one service. */
+export async function getServiceScore(slug: string): Promise<ServiceScoreViewModel | null> {
+  const payload = await fetchPayload(`/services/${encodeURIComponent(slug)}/score`);
+  return parseServiceScoreResponse(payload);
 }

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -11,3 +11,26 @@ export type ANScore = {
   tier: "emerging" | "developing" | "ready" | "native";
   explanation: string;
 };
+
+export type LeaderboardItem = {
+  serviceSlug: string;
+  name: string;
+  aggregateRecommendationScore: number | null;
+  tier: string | null;
+  confidence: number | null;
+};
+
+export type LeaderboardViewModel = {
+  category: string;
+  items: LeaderboardItem[];
+};
+
+export type ServiceScoreViewModel = {
+  serviceSlug: string;
+  aggregateRecommendationScore: number | null;
+  executionScore: number | null;
+  accessReadinessScore: number | null;
+  confidence: number | null;
+  tier: string | null;
+  explanation: string | null;
+};

--- a/packages/web/tests/adapters.contract.test.ts
+++ b/packages/web/tests/adapters.contract.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseLeaderboardResponse,
+  parseServiceScoreResponse,
+  parseServicesResponse
+} from "../lib/adapters";
+
+describe("web adapters", () => {
+  it("parses leaderboard payload contract", () => {
+    const payload = {
+      data: {
+        category: "payments",
+        items: [
+          {
+            service_slug: "stripe",
+            name: "Stripe",
+            aggregate_recommendation_score: 8.9,
+            tier: "L4",
+            confidence: 0.95
+          }
+        ]
+      },
+      error: null
+    };
+
+    const parsed = parseLeaderboardResponse(payload);
+
+    expect(parsed.category).toBe("payments");
+    expect(parsed.items).toEqual([
+      {
+        serviceSlug: "stripe",
+        name: "Stripe",
+        aggregateRecommendationScore: 8.9,
+        tier: "L4",
+        confidence: 0.95
+      }
+    ]);
+  });
+
+  it("parses score payload contract", () => {
+    const payload = {
+      service_slug: "stripe",
+      aggregate_recommendation_score: 8.9,
+      execution_score: 9.1,
+      access_readiness_score: 8.4,
+      confidence: 0.98,
+      tier: "L4",
+      explanation: "Reliable payment API"
+    };
+
+    const parsed = parseServiceScoreResponse(payload);
+
+    expect(parsed).toEqual({
+      serviceSlug: "stripe",
+      aggregateRecommendationScore: 8.9,
+      executionScore: 9.1,
+      accessReadinessScore: 8.4,
+      confidence: 0.98,
+      tier: "L4",
+      explanation: "Reliable payment API"
+    });
+  });
+
+  it("parses service list payload contract", () => {
+    const payload = {
+      data: {
+        items: [
+          {
+            slug: "stripe",
+            name: "Stripe",
+            category: "payments",
+            description: "Payments API"
+          }
+        ]
+      },
+      error: null
+    };
+
+    expect(parseServicesResponse(payload)).toEqual([
+      {
+        slug: "stripe",
+        name: "Stripe",
+        category: "payments",
+        description: "Payments API"
+      }
+    ]);
+  });
+});

--- a/packages/web/tests/routes.scaffold.test.ts
+++ b/packages/web/tests/routes.scaffold.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/api", () => ({
+  getLeaderboard: vi.fn(async () => ({ category: "payments", items: [] })),
+  getServiceScore: vi.fn(async () => ({
+    serviceSlug: "stripe",
+    aggregateRecommendationScore: 8.9,
+    executionScore: 9.1,
+    accessReadinessScore: 8.4,
+    confidence: 0.98,
+    tier: "L4",
+    explanation: "Reliable payment API"
+  }))
+}));
+
+describe("round 7 slice A route scaffold", () => {
+  it("renders home route component", async () => {
+    const module = await import("../app/page");
+    const node = module.default();
+
+    expect(node).toBeTruthy();
+  });
+
+  it("renders leaderboard route component", async () => {
+    const module = await import("../app/leaderboard/[category]/page");
+    const node = await module.default({ params: Promise.resolve({ category: "payments" }) });
+
+    expect(node).toBeTruthy();
+  });
+
+  it("renders service route component", async () => {
+    const module = await import("../app/service/[slug]/page");
+    const node = await module.default({ params: Promise.resolve({ slug: "stripe" }) });
+
+    expect(node).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add typed response adapters for services, leaderboard, and score payload contracts
- wire web API client to adapter-based parsing for `/services`, `/leaderboard/{category}`, and `/services/{slug}/score`
- scaffold `/`, `/leaderboard/[category]`, and `/service/[slug]` routes for Round 7 execution path
- add contract tests for adapter parsing and scaffold render tests for route handlers

## Testing
- cd packages/web && npm run test
- cd packages/web && npm run type-check
