### PR TITLE
Round 7 Slice B: leaderboard pages with states and query controls

### DIFF
--- a/packages/web/app/leaderboard/[category]/page.tsx
+++ b/packages/web/app/leaderboard/[category]/page.tsx
@@ -1,20 +1,118 @@
 import React from "react";
+import Link from "next/link";
 
 import { getLeaderboard } from "../../../lib/api";
+import type { LeaderboardItem } from "../../../lib/types";
+
+type SearchParams = {
+  category?: string;
+  limit?: string;
+};
+
+function normalizeCategory(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function parseLimit(value: string | undefined): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) {
+    return 10;
+  }
+
+  return Math.max(1, Math.min(parsed, 50));
+}
+
+function scoreLabel(value: number | null): string {
+  return value === null ? "Pending" : value.toFixed(1);
+}
+
+function freshnessLabel(item: LeaderboardItem): string {
+  if (item.freshness) {
+    return item.freshness;
+  }
+
+  if (item.calculatedAt) {
+    return `Updated ${item.calculatedAt}`;
+  }
+
+  return "Freshness pending";
+}
 
 export default async function LeaderboardPage({
-  params
+  params,
+  searchParams
 }: {
   params: Promise<{ category: string }>;
+  searchParams: Promise<SearchParams>;
 }): Promise<JSX.Element> {
-  const { category } = await params;
-  const leaderboard = await getLeaderboard(category);
+  const { category: routeCategory } = await params;
+  const query = await searchParams;
+
+  const category = normalizeCategory(query.category) ?? routeCategory;
+  const limit = parseLimit(query.limit);
+  const leaderboard = await getLeaderboard(category, { limit });
+
+  if (leaderboard.error) {
+    return (
+      <section>
+        <h1>{category} leaderboard</h1>
+        <p>We could not load leaderboard data right now.</p>
+        <p>{leaderboard.error}</p>
+      </section>
+    );
+  }
+
+  const visibleItems = leaderboard.items.slice(0, limit);
+  if (visibleItems.length === 0) {
+    return (
+      <section>
+        <h1>{leaderboard.category} leaderboard</h1>
+        <p>No ranked services yet for this category.</p>
+        <p>Try another category with ?category=&lt;name&gt;.</p>
+      </section>
+    );
+  }
 
   return (
     <section>
       <h1>{leaderboard.category} leaderboard</h1>
-      <p>Round 7 Slice A scaffold.</p>
-      <p>Entries loaded: {leaderboard.items.length}</p>
+      <p>
+        Showing top {visibleItems.length} result{visibleItems.length === 1 ? "" : "s"}.
+      </p>
+      <div style={{ display: "grid", gap: 12, marginTop: 16 }}>
+        {visibleItems.map((item, index) => (
+          <article
+            key={item.serviceSlug}
+            style={{ border: "1px solid #e2e8f0", borderRadius: 12, padding: 16 }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 12 }}>
+              <h2 style={{ margin: 0, fontSize: 18 }}>
+                #{index + 1} <Link href={`/service/${item.serviceSlug}`}>{item.name}</Link>
+              </h2>
+              <strong>{scoreLabel(item.aggregateRecommendationScore)}</strong>
+            </div>
+            <div style={{ display: "flex", gap: 8, marginTop: 8, flexWrap: "wrap" }}>
+              <span style={{ padding: "2px 8px", border: "1px solid #cbd5e1", borderRadius: 999 }}>
+                Execution {scoreLabel(item.executionScore)}
+              </span>
+              <span style={{ padding: "2px 8px", border: "1px solid #cbd5e1", borderRadius: 999 }}>
+                Access {scoreLabel(item.accessReadinessScore)}
+              </span>
+              <span style={{ padding: "2px 8px", border: "1px solid #cbd5e1", borderRadius: 999 }}>
+                {item.tier ?? "Tier pending"}
+              </span>
+            </div>
+            <p style={{ marginBottom: 0, marginTop: 8, color: "#475569" }}>
+              Freshness: {freshnessLabel(item)}
+            </p>
+          </article>
+        ))}
+      </div>
     </section>
   );
 }

--- a/packages/web/lib/adapters.ts
+++ b/packages/web/lib/adapters.ts
@@ -55,6 +55,10 @@ function parseLeaderboardItem(item: Record<string, unknown>): LeaderboardItem | 
     serviceSlug,
     name: asString(item.name) ?? serviceSlug,
     aggregateRecommendationScore: asNumber(item.aggregate_recommendation_score),
+    executionScore: asNumber(item.execution_score),
+    accessReadinessScore: asNumber(item.access_readiness_score),
+    freshness: asString(item.probe_freshness) ?? asString(item.freshness),
+    calculatedAt: asString(item.calculated_at),
     tier: asString(item.tier),
     confidence: asNumber(item.confidence)
   };
@@ -62,7 +66,7 @@ function parseLeaderboardItem(item: Record<string, unknown>): LeaderboardItem | 
 
 export function parseLeaderboardResponse(payload: unknown): LeaderboardViewModel {
   if (!isRecord(payload) || !isRecord(payload.data)) {
-    return { category: "unknown", items: [] };
+    return { category: "unknown", items: [], error: "Invalid leaderboard payload" };
   }
 
   const category = asString(payload.data.category) ?? "unknown";
@@ -70,7 +74,7 @@ export function parseLeaderboardResponse(payload: unknown): LeaderboardViewModel
     .map((item) => parseLeaderboardItem(item))
     .filter((item): item is LeaderboardItem => item !== null);
 
-  return { category, items };
+  return { category, items, error: null };
 }
 
 export function parseServiceScoreResponse(payload: unknown): ServiceScoreViewModel | null {

--- a/packages/web/lib/api.ts
+++ b/packages/web/lib/api.ts
@@ -4,12 +4,16 @@ import type { LeaderboardViewModel, Service, ServiceScoreViewModel } from "./typ
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/v1";
 
 async function fetchPayload(path: string): Promise<unknown> {
-  const response = await fetch(`${API_BASE}${path}`, { cache: "no-store" });
-  if (!response.ok) {
+  try {
+    const response = await fetch(`${API_BASE}${path}`, { cache: "no-store" });
+    if (!response.ok) {
+      return null;
+    }
+
+    return (await response.json()) as unknown;
+  } catch {
     return null;
   }
-
-  return (await response.json()) as unknown;
 }
 
 /** Fetch all services. */
@@ -19,9 +23,30 @@ export async function getServices(): Promise<Service[]> {
 }
 
 /** Fetch category leaderboard. */
-export async function getLeaderboard(category: string): Promise<LeaderboardViewModel> {
-  const payload = await fetchPayload(`/leaderboard/${encodeURIComponent(category)}`);
-  return parseLeaderboardResponse(payload);
+export async function getLeaderboard(
+  category: string,
+  options?: { limit?: number }
+): Promise<LeaderboardViewModel> {
+  const params = new URLSearchParams();
+  if (options?.limit !== undefined) {
+    params.set("limit", String(options.limit));
+  }
+
+  const suffix = params.toString().length > 0 ? `?${params.toString()}` : "";
+  const payload = await fetchPayload(`/leaderboard/${encodeURIComponent(category)}${suffix}`);
+  if (payload === null) {
+    return {
+      category,
+      items: [],
+      error: "Unable to load leaderboard right now."
+    };
+  }
+
+  const parsed = parseLeaderboardResponse(payload);
+  return {
+    ...parsed,
+    category: parsed.category === "unknown" ? category : parsed.category
+  };
 }
 
 /** Fetch latest score details for one service. */

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -16,6 +16,10 @@ export type LeaderboardItem = {
   serviceSlug: string;
   name: string;
   aggregateRecommendationScore: number | null;
+  executionScore: number | null;
+  accessReadinessScore: number | null;
+  freshness: string | null;
+  calculatedAt: string | null;
   tier: string | null;
   confidence: number | null;
 };
@@ -23,6 +27,7 @@ export type LeaderboardItem = {
 export type LeaderboardViewModel = {
   category: string;
   items: LeaderboardItem[];
+  error: string | null;
 };
 
 export type ServiceScoreViewModel = {

--- a/packages/web/tests/adapters.contract.test.ts
+++ b/packages/web/tests/adapters.contract.test.ts
@@ -16,6 +16,10 @@ describe("web adapters", () => {
             service_slug: "stripe",
             name: "Stripe",
             aggregate_recommendation_score: 8.9,
+            execution_score: 9.1,
+            access_readiness_score: 8.4,
+            probe_freshness: "12 minutes ago",
+            calculated_at: "2026-03-05T22:00:00Z",
             tier: "L4",
             confidence: 0.95
           }
@@ -32,10 +36,25 @@ describe("web adapters", () => {
         serviceSlug: "stripe",
         name: "Stripe",
         aggregateRecommendationScore: 8.9,
+        executionScore: 9.1,
+        accessReadinessScore: 8.4,
+        freshness: "12 minutes ago",
+        calculatedAt: "2026-03-05T22:00:00Z",
         tier: "L4",
         confidence: 0.95
       }
     ]);
+    expect(parsed.error).toBeNull();
+  });
+
+  it("returns a typed error for invalid leaderboard payload", () => {
+    const parsed = parseLeaderboardResponse(null);
+
+    expect(parsed).toEqual({
+      category: "unknown",
+      items: [],
+      error: "Invalid leaderboard payload"
+    });
   });
 
   it("parses score payload contract", () => {

--- a/packages/web/tests/leaderboard.page.test.ts
+++ b/packages/web/tests/leaderboard.page.test.ts
@@ -1,0 +1,99 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getLeaderboardMock } = vi.hoisted(() => ({
+  getLeaderboardMock: vi.fn()
+}));
+
+vi.mock("../lib/api", () => ({
+  getLeaderboard: getLeaderboardMock
+}));
+
+type PageInput = {
+  params?: { category: string };
+  searchParams?: { category?: string; limit?: string };
+};
+
+async function renderLeaderboardPage(input: PageInput = {}): Promise<string> {
+  const module = await import("../app/leaderboard/[category]/page");
+  const page = await module.default({
+    params: Promise.resolve(input.params ?? { category: "payments" }),
+    searchParams: Promise.resolve(input.searchParams ?? {})
+  });
+
+  return renderToStaticMarkup(page);
+}
+
+describe("leaderboard page", () => {
+  beforeEach(() => {
+    getLeaderboardMock.mockReset();
+  });
+
+  it("renders ranked entries with execution/access badges and freshness", async () => {
+    getLeaderboardMock.mockResolvedValue({
+      category: "payments",
+      error: null,
+      items: [
+        {
+          serviceSlug: "stripe",
+          name: "Stripe",
+          aggregateRecommendationScore: 8.9,
+          executionScore: 9.1,
+          accessReadinessScore: 8.4,
+          freshness: "12 minutes ago",
+          calculatedAt: null,
+          tier: "L4",
+          confidence: 0.95
+        },
+        {
+          serviceSlug: "resend",
+          name: "Resend",
+          aggregateRecommendationScore: 8.1,
+          executionScore: 8.3,
+          accessReadinessScore: 7.8,
+          freshness: "2 hours ago",
+          calculatedAt: null,
+          tier: "L3",
+          confidence: 0.9
+        }
+      ]
+    });
+
+    const html = await renderLeaderboardPage({ searchParams: { limit: "1" } });
+
+    expect(getLeaderboardMock).toHaveBeenCalledWith("payments", { limit: 1 });
+    expect(html).toContain("#1");
+    expect(html).toContain("Execution 9.1");
+    expect(html).toContain("Access 8.4");
+    expect(html).toContain("Freshness: 12 minutes ago");
+    expect(html).not.toContain("Resend");
+  });
+
+  it("renders empty state snapshot", async () => {
+    getLeaderboardMock.mockResolvedValue({
+      category: "payments",
+      error: null,
+      items: []
+    });
+
+    const html = await renderLeaderboardPage();
+
+    expect(html).toMatchInlineSnapshot(
+      '"<section><h1>payments leaderboard</h1><p>No ranked services yet for this category.</p><p>Try another category with ?category=&lt;name&gt;.</p></section>"'
+    );
+  });
+
+  it("renders error state snapshot", async () => {
+    getLeaderboardMock.mockResolvedValue({
+      category: "payments",
+      error: "Unable to load leaderboard right now.",
+      items: []
+    });
+
+    const html = await renderLeaderboardPage();
+
+    expect(html).toMatchInlineSnapshot(
+      '"<section><h1>payments leaderboard</h1><p>We could not load leaderboard data right now.</p><p>Unable to load leaderboard right now.</p></section>"'
+    );
+  });
+});

--- a/packages/web/tests/routes.scaffold.test.ts
+++ b/packages/web/tests/routes.scaffold.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../lib/api", () => ({
-  getLeaderboard: vi.fn(async () => ({ category: "payments", items: [] })),
+  getLeaderboard: vi.fn(async () => ({ category: "payments", items: [], error: null })),
   getServiceScore: vi.fn(async () => ({
     serviceSlug: "stripe",
     aggregateRecommendationScore: 8.9,
@@ -23,7 +23,10 @@ describe("round 7 slice A route scaffold", () => {
 
   it("renders leaderboard route component", async () => {
     const module = await import("../app/leaderboard/[category]/page");
-    const node = await module.default({ params: Promise.resolve({ category: "payments" }) });
+    const node = await module.default({
+      params: Promise.resolve({ category: "payments" }),
+      searchParams: Promise.resolve({})
+    });
 
     expect(node).toBeTruthy();
   });


### PR DESCRIPTION
## Summary
- implement `/leaderboard/[category]` with ranked cards (rank, aggregate score, execution/access badges, freshness)
- add query param support for `category` and `limit` plus server-side limit clamping
- add resilient empty and API-error states for leaderboard fetches
- extend leaderboard adapter/types for execution/access/freshness fields and typed parse errors
- add leaderboard page tests covering ranked render + empty/error snapshots

## Testing
- cd packages/web && npm run test
- cd packages/web && npm run type-check
