### PR TITLE
Round 7 Slice C: service profile pages with failures and alternatives

### DIFF
--- a/packages/web/app/service/[slug]/page.tsx
+++ b/packages/web/app/service/[slug]/page.tsx
@@ -1,6 +1,25 @@
 import React from "react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
 
 import { getServiceScore } from "../../../lib/api";
+import type { ServiceScoreViewModel } from "../../../lib/types";
+
+function scoreLabel(value: number | null): string {
+  return value === null ? "Pending" : value.toFixed(1);
+}
+
+function freshnessLabel(score: ServiceScoreViewModel): string {
+  if (score.evidenceFreshness) {
+    return score.evidenceFreshness;
+  }
+
+  if (score.calculatedAt) {
+    return `Updated ${score.calculatedAt}`;
+  }
+
+  return "Freshness pending";
+}
 
 export default async function ServicePage({
   params
@@ -10,13 +29,69 @@ export default async function ServicePage({
   const { slug } = await params;
   const score = await getServiceScore(slug);
 
+  if (score === null) {
+    notFound();
+  }
+
   return (
     <section>
-      <h1>Service: {slug}</h1>
-      <p>Round 7 Slice A scaffold.</p>
-      <p>
-        Aggregate recommendation score: {score?.aggregateRecommendationScore ?? "pending"}
+      <h1>{score.serviceSlug}</h1>
+      <p style={{ marginTop: 8, color: "#475569" }}>Freshness: {freshnessLabel(score)}</p>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 12 }}>
+        <strong
+          style={{
+            padding: "4px 10px",
+            borderRadius: 999,
+            background: "#0f172a",
+            color: "#fff"
+          }}
+        >
+          Aggregate {scoreLabel(score.aggregateRecommendationScore)}
+        </strong>
+        <span style={{ padding: "4px 10px", borderRadius: 999, border: "1px solid #cbd5e1" }}>
+          Execution {scoreLabel(score.executionScore)}
+        </span>
+        <span style={{ padding: "4px 10px", borderRadius: 999, border: "1px solid #cbd5e1" }}>
+          Access {scoreLabel(score.accessReadinessScore)}
+        </span>
+      </div>
+
+      <p style={{ marginTop: 12 }}>
+        Tier: <strong>{score.tierLabel ?? score.tier ?? "Pending"}</strong>
+        {score.confidence !== null ? ` · Confidence ${score.confidence.toFixed(2)}` : ""}
       </p>
+
+      <p>{score.explanation ?? "Explanation pending."}</p>
+
+      <section style={{ marginTop: 20 }}>
+        <h2 style={{ marginBottom: 8 }}>Active failure modes</h2>
+        {score.activeFailures.length > 0 ? (
+          <ul style={{ marginTop: 0 }}>
+            {score.activeFailures.map((failure) => (
+              <li key={failure.id ?? failure.summary}>{failure.summary}</li>
+            ))}
+          </ul>
+        ) : (
+          <p style={{ marginTop: 0 }}>No active failure modes reported.</p>
+        )}
+      </section>
+
+      <section style={{ marginTop: 20 }}>
+        <h2 style={{ marginBottom: 8 }}>Alternatives</h2>
+        {score.alternatives.length > 0 ? (
+          <ul style={{ marginTop: 0 }}>
+            {score.alternatives.map((alternative) => (
+              <li key={alternative.serviceSlug}>
+                <Link href={`/service/${alternative.serviceSlug}`}>{alternative.serviceSlug}</Link>
+                {alternative.score !== null ? ` (${alternative.score.toFixed(1)})` : ""}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p style={{ marginTop: 0 }}>No alternatives captured yet.</p>
+        )}
+      </section>
     </section>
   );
 }

--- a/packages/web/lib/adapters.ts
+++ b/packages/web/lib/adapters.ts
@@ -1,4 +1,11 @@
-import type { LeaderboardItem, LeaderboardViewModel, Service, ServiceScoreViewModel } from "./types";
+import type {
+  LeaderboardItem,
+  LeaderboardViewModel,
+  Service,
+  ServiceAlternative,
+  ServiceFailureMode,
+  ServiceScoreViewModel
+} from "./types";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -77,6 +84,38 @@ export function parseLeaderboardResponse(payload: unknown): LeaderboardViewModel
   return { category, items, error: null };
 }
 
+function parseFailureMode(item: Record<string, unknown>): ServiceFailureMode | null {
+  const summary = asString(item.summary);
+  if (!summary) {
+    return null;
+  }
+
+  return {
+    id: asString(item.id),
+    summary
+  };
+}
+
+function parseAlternative(item: Record<string, unknown>): ServiceAlternative | null {
+  const serviceSlug = asString(item.service) ?? asString(item.service_slug);
+  if (!serviceSlug) {
+    return null;
+  }
+
+  return {
+    serviceSlug,
+    score: asNumber(item.score)
+  };
+}
+
+function parseEvidenceFreshness(snapshot: Record<string, unknown>): string | null {
+  return (
+    asString(snapshot.probe_freshness) ??
+    asString(snapshot.freshness) ??
+    asString(snapshot.evidence_freshness)
+  );
+}
+
 export function parseServiceScoreResponse(payload: unknown): ServiceScoreViewModel | null {
   if (!isRecord(payload)) {
     return null;
@@ -87,6 +126,14 @@ export function parseServiceScoreResponse(payload: unknown): ServiceScoreViewMod
     return null;
   }
 
+  const snapshot = isRecord(payload.dimension_snapshot) ? payload.dimension_snapshot : {};
+  const activeFailures = asItems(snapshot.active_failures)
+    .map((item) => parseFailureMode(item))
+    .filter((item): item is ServiceFailureMode => item !== null);
+  const alternatives = asItems(snapshot.alternatives)
+    .map((item) => parseAlternative(item))
+    .filter((item): item is ServiceAlternative => item !== null);
+
   return {
     serviceSlug,
     aggregateRecommendationScore: asNumber(payload.aggregate_recommendation_score),
@@ -94,6 +141,11 @@ export function parseServiceScoreResponse(payload: unknown): ServiceScoreViewMod
     accessReadinessScore: asNumber(payload.access_readiness_score),
     confidence: asNumber(payload.confidence),
     tier: asString(payload.tier),
-    explanation: asString(payload.explanation)
+    tierLabel: asString(payload.tier_label),
+    explanation: asString(payload.explanation),
+    calculatedAt: asString(payload.calculated_at),
+    evidenceFreshness: parseEvidenceFreshness(snapshot) ?? asString(payload.probe_freshness),
+    activeFailures,
+    alternatives
   };
 }

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -30,6 +30,16 @@ export type LeaderboardViewModel = {
   error: string | null;
 };
 
+export type ServiceFailureMode = {
+  id: string | null;
+  summary: string;
+};
+
+export type ServiceAlternative = {
+  serviceSlug: string;
+  score: number | null;
+};
+
 export type ServiceScoreViewModel = {
   serviceSlug: string;
   aggregateRecommendationScore: number | null;
@@ -37,5 +47,10 @@ export type ServiceScoreViewModel = {
   accessReadinessScore: number | null;
   confidence: number | null;
   tier: string | null;
+  tierLabel: string | null;
   explanation: string | null;
+  calculatedAt: string | null;
+  evidenceFreshness: string | null;
+  activeFailures: ServiceFailureMode[];
+  alternatives: ServiceAlternative[];
 };

--- a/packages/web/tests/adapters.contract.test.ts
+++ b/packages/web/tests/adapters.contract.test.ts
@@ -65,7 +65,24 @@ describe("web adapters", () => {
       access_readiness_score: 8.4,
       confidence: 0.98,
       tier: "L4",
-      explanation: "Reliable payment API"
+      tier_label: "Agent Native",
+      explanation: "Reliable payment API",
+      calculated_at: "2026-03-05T23:00:00Z",
+      dimension_snapshot: {
+        probe_freshness: "12 minutes ago",
+        active_failures: [
+          {
+            id: "AF-oauth-redirect",
+            summary: "Token refresh requires browser redirect in some flows"
+          }
+        ],
+        alternatives: [
+          {
+            service: "square",
+            score: 7.4
+          }
+        ]
+      }
     };
 
     const parsed = parseServiceScoreResponse(payload);
@@ -77,7 +94,22 @@ describe("web adapters", () => {
       accessReadinessScore: 8.4,
       confidence: 0.98,
       tier: "L4",
-      explanation: "Reliable payment API"
+      tierLabel: "Agent Native",
+      explanation: "Reliable payment API",
+      calculatedAt: "2026-03-05T23:00:00Z",
+      evidenceFreshness: "12 minutes ago",
+      activeFailures: [
+        {
+          id: "AF-oauth-redirect",
+          summary: "Token refresh requires browser redirect in some flows"
+        }
+      ],
+      alternatives: [
+        {
+          serviceSlug: "square",
+          score: 7.4
+        }
+      ]
     });
   });
 

--- a/packages/web/tests/routes.scaffold.test.ts
+++ b/packages/web/tests/routes.scaffold.test.ts
@@ -9,7 +9,12 @@ vi.mock("../lib/api", () => ({
     accessReadinessScore: 8.4,
     confidence: 0.98,
     tier: "L4",
-    explanation: "Reliable payment API"
+    tierLabel: "Agent Native",
+    explanation: "Reliable payment API",
+    calculatedAt: "2026-03-05T23:00:00Z",
+    evidenceFreshness: "12 minutes ago",
+    activeFailures: [],
+    alternatives: []
   }))
 }));
 

--- a/packages/web/tests/service.page.test.ts
+++ b/packages/web/tests/service.page.test.ts
@@ -1,0 +1,77 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getServiceScoreMock, notFoundMock } = vi.hoisted(() => ({
+  getServiceScoreMock: vi.fn(),
+  notFoundMock: vi.fn()
+}));
+
+vi.mock("../lib/api", () => ({
+  getServiceScore: getServiceScoreMock
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: notFoundMock
+}));
+
+async function renderServicePage(slug = "stripe"): Promise<string> {
+  const module = await import("../app/service/[slug]/page");
+  const page = await module.default({ params: Promise.resolve({ slug }) });
+  return renderToStaticMarkup(page);
+}
+
+describe("service page", () => {
+  beforeEach(() => {
+    getServiceScoreMock.mockReset();
+    notFoundMock.mockReset();
+    notFoundMock.mockImplementation(() => {
+      throw new Error("NEXT_NOT_FOUND");
+    });
+  });
+
+  it("renders score breakdown, explanation, failures, and alternatives", async () => {
+    getServiceScoreMock.mockResolvedValue({
+      serviceSlug: "stripe",
+      aggregateRecommendationScore: 8.9,
+      executionScore: 9.1,
+      accessReadinessScore: 8.4,
+      confidence: 0.98,
+      tier: "L4",
+      tierLabel: "Agent Native",
+      explanation: "Reliable payment API",
+      calculatedAt: "2026-03-05T23:00:00Z",
+      evidenceFreshness: "12 minutes ago",
+      activeFailures: [
+        {
+          id: "AF-oauth-redirect",
+          summary: "Token refresh requires browser redirect in some flows"
+        }
+      ],
+      alternatives: [
+        {
+          serviceSlug: "square",
+          score: 7.4
+        }
+      ]
+    });
+
+    const html = await renderServicePage();
+
+    expect(html).toContain("Aggregate 8.9");
+    expect(html).toContain("Execution 9.1");
+    expect(html).toContain("Access 8.4");
+    expect(html).toContain("Tier: <strong>Agent Native</strong> · Confidence 0.98");
+    expect(html).toContain("Reliable payment API");
+    expect(html).toContain("Token refresh requires browser redirect in some flows");
+    expect(html).toContain("href=\"/service/square\"");
+    expect(html).toContain("square</a> (7.4)");
+    expect(notFoundMock).not.toHaveBeenCalled();
+  });
+
+  it("maps missing services to not-found", async () => {
+    getServiceScoreMock.mockResolvedValue(null);
+
+    await expect(renderServicePage("missing-service")).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(notFoundMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `/service/[slug]` page with aggregate/execution/access breakout, tier+confidence, freshness, and contextual explanation
- map missing services to Next.js `notFound()` state
- parse richer score response fields (tier label, calculated timestamp, evidence freshness, active failures, alternatives)
- add service page tests for full Stripe fixture render and not-found behavior
- extend adapter contract tests and route scaffold mocks to cover enriched score view model

## Testing
- cd packages/web && npm run test
- cd packages/web && npm run type-check
