### PR TITLE
Round 7 Slice D: homepage preview + machine-discovery metadata

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,10 +1,25 @@
 # rhumb-web
 
-Next.js 15 App Router scaffold for Rhumb.
+Next.js 15 App Router app for Rhumb Discover surfaces.
 
-## Run
+## Local run
 
 ```bash
 npm ci
 npm run dev
 ```
+
+Optional checks:
+
+```bash
+npm run test
+npm run type-check
+```
+
+## Route map
+
+- `/` — homepage hero + search entry + leaderboard preview
+- `/leaderboard/[category]` — category leaderboard with aggregate/execution/access badges
+- `/service/[slug]` — service profile, contextual explanation, failures, alternatives
+- `/search` — service search entrypoint
+- `/llms.txt` — machine-discovery baseline export

--- a/packages/web/app/leaderboard/[category]/page.tsx
+++ b/packages/web/app/leaderboard/[category]/page.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Link from "next/link";
+import type { Metadata } from "next";
 
 import { getLeaderboard } from "../../../lib/api";
 import type { LeaderboardItem } from "../../../lib/types";
@@ -43,6 +44,73 @@ function freshnessLabel(item: LeaderboardItem): string {
   return "Freshness pending";
 }
 
+function buildLeaderboardJsonLd(category: string, items: LeaderboardItem[]): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `${category} leaderboard`,
+    itemListOrder: "https://schema.org/ItemListOrderAscending",
+    numberOfItems: items.length,
+    itemListElement: items.map((item, index) => {
+      const additionalProperty = [
+        item.aggregateRecommendationScore !== null
+          ? {
+              "@type": "PropertyValue",
+              name: "aggregate_recommendation_score",
+              value: item.aggregateRecommendationScore.toFixed(1)
+            }
+          : null,
+        item.executionScore !== null
+          ? {
+              "@type": "PropertyValue",
+              name: "execution_score",
+              value: item.executionScore.toFixed(1)
+            }
+          : null,
+        item.accessReadinessScore !== null
+          ? {
+              "@type": "PropertyValue",
+              name: "access_readiness_score",
+              value: item.accessReadinessScore.toFixed(1)
+            }
+          : null
+      ].filter(
+        (property): property is { "@type": "PropertyValue"; name: string; value: string } =>
+          property !== null
+      );
+
+      return {
+        "@type": "ListItem",
+        position: index + 1,
+        item: {
+          "@type": "SoftwareApplication",
+          name: item.name,
+          url: `/service/${item.serviceSlug}`,
+          identifier: item.serviceSlug,
+          ...(additionalProperty.length > 0 ? { additionalProperty } : {})
+        }
+      };
+    })
+  };
+}
+
+function renderJsonLd(payload: Record<string, unknown>): JSX.Element {
+  return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(payload) }} />;
+}
+
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ category: string }>;
+}): Promise<Metadata> {
+  const { category } = await params;
+
+  return {
+    title: `${category} leaderboard | Rhumb`,
+    description: `Top agent-native services in ${category} ranked by aggregate, execution, and access-readiness scores.`
+  };
+}
+
 export default async function LeaderboardPage({
   params,
   searchParams
@@ -57,9 +125,14 @@ export default async function LeaderboardPage({
   const limit = parseLimit(query.limit);
   const leaderboard = await getLeaderboard(category, { limit });
 
+  const resolvedCategory = leaderboard.error ? category : leaderboard.category;
+  const visibleItems = leaderboard.error ? [] : leaderboard.items.slice(0, limit);
+  const structuredData = buildLeaderboardJsonLd(resolvedCategory, visibleItems);
+
   if (leaderboard.error) {
     return (
       <section>
+        {renderJsonLd(structuredData)}
         <h1>{category} leaderboard</h1>
         <p>We could not load leaderboard data right now.</p>
         <p>{leaderboard.error}</p>
@@ -67,10 +140,10 @@ export default async function LeaderboardPage({
     );
   }
 
-  const visibleItems = leaderboard.items.slice(0, limit);
   if (visibleItems.length === 0) {
     return (
       <section>
+        {renderJsonLd(structuredData)}
         <h1>{leaderboard.category} leaderboard</h1>
         <p>No ranked services yet for this category.</p>
         <p>Try another category with ?category=&lt;name&gt;.</p>
@@ -80,6 +153,7 @@ export default async function LeaderboardPage({
 
   return (
     <section>
+      {renderJsonLd(structuredData)}
       <h1>{leaderboard.category} leaderboard</h1>
       <p>
         Showing top {visibleItems.length} result{visibleItems.length === 1 ? "" : "s"}.

--- a/packages/web/app/llms.txt
+++ b/packages/web/app/llms.txt
@@ -1,2 +1,22 @@
+# Rhumb Web
+
 Rhumb is an agent-native tool discovery and scoring platform.
-Public endpoints are documented at /v1/* via the API package.
+
+## Public routes
+- / — homepage with search entry and leaderboard preview
+- /leaderboard/{category} — ranked services for a category
+- /service/{slug} — service profile with aggregate/execution/access scoring
+- /search — service search UI
+
+## Scoring model surface
+Service and leaderboard pages expose:
+- Aggregate recommendation score (0-10)
+- Execution score (runtime reliability/ergonomics)
+- Access readiness score (credential/provisioning feasibility)
+- Confidence and tier labels
+- Probe freshness and failure-mode context when available
+
+## API dependencies
+- /v1/leaderboard/{category}
+- /v1/services/{slug}/score
+- /v1/services

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,19 +1,87 @@
 import React from "react";
 import Link from "next/link";
+import type { Metadata } from "next";
 
-export default function HomePage(): JSX.Element {
+import { getLeaderboard } from "../lib/api";
+import type { LeaderboardItem } from "../lib/types";
+
+export const metadata: Metadata = {
+  title: "Rhumb | Agent-native tool discovery",
+  description: "Discover top agent-native services with execution and access-readiness evidence."
+};
+
+function scoreLabel(value: number | null): string {
+  return value === null ? "Pending" : value.toFixed(1);
+}
+
+function freshnessLabel(item: LeaderboardItem): string {
+  if (item.freshness) {
+    return item.freshness;
+  }
+
+  if (item.calculatedAt) {
+    return `Updated ${item.calculatedAt}`;
+  }
+
+  return "Freshness pending";
+}
+
+export default async function HomePage(): Promise<JSX.Element> {
+  const leaderboard = await getLeaderboard("payments", { limit: 3 });
+  const previewItems = leaderboard.items.slice(0, 3);
+
   return (
     <section>
-      <h1>Rhumb</h1>
-      <p>Agent-native tool discovery and scoring.</p>
-      <ul style={{ display: "grid", gap: 8, marginTop: 16 }}>
-        <li>
-          <Link href="/leaderboard/payments">View payments leaderboard</Link>
-        </li>
-        <li>
-          <Link href="/service/stripe">View service scaffold (stripe)</Link>
-        </li>
-      </ul>
+      <header>
+        <h1>Find agent-native services in seconds</h1>
+        <p style={{ marginTop: 8 }}>
+          Rhumb maps execution reliability and access readiness so your agents pick the right primitive
+          before they fail in production.
+        </p>
+
+        <form
+          action="/search"
+          method="get"
+          style={{ display: "flex", gap: 8, marginTop: 16, flexWrap: "wrap" }}
+        >
+          <input
+            aria-label="Search services"
+            name="q"
+            placeholder="Search services (e.g. payments API)"
+            style={{ minWidth: 260, padding: "8px 10px", borderRadius: 8, border: "1px solid #cbd5e1" }}
+          />
+          <button type="submit" style={{ padding: "8px 12px", borderRadius: 8 }}>
+            Search
+          </button>
+        </form>
+
+        <p style={{ marginTop: 12 }}>
+          <Link href="/leaderboard/payments">Open full payments leaderboard</Link>
+        </p>
+      </header>
+
+      <section style={{ marginTop: 28 }}>
+        <h2>Top services in payments</h2>
+        {leaderboard.error ? (
+          <p>
+            Live leaderboard preview is temporarily unavailable. You can still browse the
+            <span> </span>
+            <Link href="/leaderboard/payments">full leaderboard</Link>.
+          </p>
+        ) : previewItems.length === 0 ? (
+          <p>No ranked services published yet.</p>
+        ) : (
+          <ol style={{ display: "grid", gap: 10, marginTop: 12, paddingLeft: 18 }}>
+            {previewItems.map((item) => (
+              <li key={item.serviceSlug}>
+                <Link href={`/service/${item.serviceSlug}`}>{item.name}</Link>
+                <span>{` · Aggregate ${scoreLabel(item.aggregateRecommendationScore)}`}</span>
+                <span>{` · Freshness ${freshnessLabel(item)}`}</span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
     </section>
   );
 }

--- a/packages/web/app/service/[slug]/page.tsx
+++ b/packages/web/app/service/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Link from "next/link";
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { getServiceScore } from "../../../lib/api";
@@ -21,6 +22,74 @@ function freshnessLabel(score: ServiceScoreViewModel): string {
   return "Freshness pending";
 }
 
+function buildServiceJsonLd(score: ServiceScoreViewModel): Record<string, unknown> {
+  const additionalProperty = [
+    score.executionScore !== null
+      ? {
+          "@type": "PropertyValue",
+          name: "execution_score",
+          value: score.executionScore.toFixed(1)
+        }
+      : null,
+    score.accessReadinessScore !== null
+      ? {
+          "@type": "PropertyValue",
+          name: "access_readiness_score",
+          value: score.accessReadinessScore.toFixed(1)
+        }
+      : null,
+    score.tierLabel ?? score.tier
+      ? {
+          "@type": "PropertyValue",
+          name: "tier",
+          value: score.tierLabel ?? score.tier ?? "Pending"
+        }
+      : null,
+    score.confidence !== null
+      ? {
+          "@type": "PropertyValue",
+          name: "confidence",
+          value: score.confidence.toFixed(2)
+        }
+      : null
+  ].filter((property): property is { "@type": "PropertyValue"; name: string; value: string } => property !== null);
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: score.serviceSlug,
+    url: `/service/${score.serviceSlug}`,
+    description: score.explanation ?? "AN Score profile from Rhumb",
+    ...(score.aggregateRecommendationScore !== null
+      ? {
+          aggregateRating: {
+            "@type": "Rating",
+            ratingValue: score.aggregateRecommendationScore.toFixed(1),
+            bestRating: "10"
+          }
+        }
+      : {}),
+    ...(additionalProperty.length > 0 ? { additionalProperty } : {})
+  };
+}
+
+function renderJsonLd(payload: Record<string, unknown>): JSX.Element {
+  return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(payload) }} />;
+}
+
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+
+  return {
+    title: `${slug} service profile | Rhumb`,
+    description: `Execution and access-readiness profile for ${slug} with live AN Score evidence.`
+  };
+}
+
 export default async function ServicePage({
   params
 }: {
@@ -33,8 +102,11 @@ export default async function ServicePage({
     notFound();
   }
 
+  const structuredData = buildServiceJsonLd(score);
+
   return (
     <section>
+      {renderJsonLd(structuredData)}
       <h1>{score.serviceSlug}</h1>
       <p style={{ marginTop: 8, color: "#475569" }}>Freshness: {freshnessLabel(score)}</p>
 

--- a/packages/web/tests/home.page.test.ts
+++ b/packages/web/tests/home.page.test.ts
@@ -1,0 +1,65 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getLeaderboardMock } = vi.hoisted(() => ({
+  getLeaderboardMock: vi.fn()
+}));
+
+vi.mock("../lib/api", () => ({
+  getLeaderboard: getLeaderboardMock
+}));
+
+async function renderHomePage(): Promise<string> {
+  const module = await import("../app/page");
+  const page = await module.default();
+  return renderToStaticMarkup(page);
+}
+
+describe("home page", () => {
+  beforeEach(() => {
+    getLeaderboardMock.mockReset();
+  });
+
+  it("renders hero, search entry, and leaderboard preview", async () => {
+    getLeaderboardMock.mockResolvedValue({
+      category: "payments",
+      error: null,
+      items: [
+        {
+          serviceSlug: "stripe",
+          name: "Stripe",
+          aggregateRecommendationScore: 8.9,
+          executionScore: 9.1,
+          accessReadinessScore: 8.4,
+          freshness: "12 minutes ago",
+          calculatedAt: null,
+          tier: "L4",
+          confidence: 0.95
+        }
+      ]
+    });
+
+    const html = await renderHomePage();
+
+    expect(getLeaderboardMock).toHaveBeenCalledWith("payments", { limit: 3 });
+    expect(html).toContain("Find agent-native services in seconds");
+    expect(html).toContain("placeholder=\"Search services (e.g. payments API)\"");
+    expect(html).toContain("Open full payments leaderboard");
+    expect(html).toContain("Stripe</a>");
+    expect(html).toContain("Aggregate 8.9");
+  });
+
+  it("renders even when leaderboard preview fails", async () => {
+    getLeaderboardMock.mockResolvedValue({
+      category: "payments",
+      error: "Unable to load leaderboard right now.",
+      items: []
+    });
+
+    const html = await renderHomePage();
+
+    expect(html).toContain("Find agent-native services in seconds");
+    expect(html).toContain("Live leaderboard preview is temporarily unavailable.");
+    expect(html).toContain("full leaderboard");
+  });
+});

--- a/packages/web/tests/leaderboard.page.test.ts
+++ b/packages/web/tests/leaderboard.page.test.ts
@@ -29,6 +29,14 @@ describe("leaderboard page", () => {
     getLeaderboardMock.mockReset();
   });
 
+  it("generates baseline metadata", async () => {
+    const module = await import("../app/leaderboard/[category]/page");
+    const metadata = await module.generateMetadata({ params: Promise.resolve({ category: "payments" }) });
+
+    expect(metadata.title).toBe("payments leaderboard | Rhumb");
+    expect(metadata.description).toContain("payments");
+  });
+
   it("renders ranked entries with execution/access badges and freshness", async () => {
     getLeaderboardMock.mockResolvedValue({
       category: "payments",
@@ -66,6 +74,9 @@ describe("leaderboard page", () => {
     expect(html).toContain("Execution 9.1");
     expect(html).toContain("Access 8.4");
     expect(html).toContain("Freshness: 12 minutes ago");
+    expect(html).toContain("application/ld+json");
+    expect(html).toContain('"@type":"ItemList"');
+    expect(html).toContain('"name":"payments leaderboard"');
     expect(html).not.toContain("Resend");
   });
 
@@ -79,7 +90,7 @@ describe("leaderboard page", () => {
     const html = await renderLeaderboardPage();
 
     expect(html).toMatchInlineSnapshot(
-      '"<section><h1>payments leaderboard</h1><p>No ranked services yet for this category.</p><p>Try another category with ?category=&lt;name&gt;.</p></section>"'
+      '"<section><script type=\"application/ld+json\">{\"@context\":\"https://schema.org\",\"@type\":\"ItemList\",\"name\":\"payments leaderboard\",\"itemListOrder\":\"https://schema.org/ItemListOrderAscending\",\"numberOfItems\":0,\"itemListElement\":[]}</script><h1>payments leaderboard</h1><p>No ranked services yet for this category.</p><p>Try another category with ?category=&lt;name&gt;.</p></section>"'
     );
   });
 
@@ -93,7 +104,7 @@ describe("leaderboard page", () => {
     const html = await renderLeaderboardPage();
 
     expect(html).toMatchInlineSnapshot(
-      '"<section><h1>payments leaderboard</h1><p>We could not load leaderboard data right now.</p><p>Unable to load leaderboard right now.</p></section>"'
+      '"<section><script type=\"application/ld+json\">{\"@context\":\"https://schema.org\",\"@type\":\"ItemList\",\"name\":\"payments leaderboard\",\"itemListOrder\":\"https://schema.org/ItemListOrderAscending\",\"numberOfItems\":0,\"itemListElement\":[]}</script><h1>payments leaderboard</h1><p>We could not load leaderboard data right now.</p><p>Unable to load leaderboard right now.</p></section>"'
     );
   });
 });

--- a/packages/web/tests/routes.scaffold.test.ts
+++ b/packages/web/tests/routes.scaffold.test.ts
@@ -21,7 +21,7 @@ vi.mock("../lib/api", () => ({
 describe("round 7 slice A route scaffold", () => {
   it("renders home route component", async () => {
     const module = await import("../app/page");
-    const node = module.default();
+    const node = await module.default();
 
     expect(node).toBeTruthy();
   });

--- a/packages/web/tests/service.page.test.ts
+++ b/packages/web/tests/service.page.test.ts
@@ -29,6 +29,14 @@ describe("service page", () => {
     });
   });
 
+  it("generates baseline metadata", async () => {
+    const module = await import("../app/service/[slug]/page");
+    const metadata = await module.generateMetadata({ params: Promise.resolve({ slug: "stripe" }) });
+
+    expect(metadata.title).toBe("stripe service profile | Rhumb");
+    expect(metadata.description).toContain("stripe");
+  });
+
   it("renders score breakdown, explanation, failures, and alternatives", async () => {
     getServiceScoreMock.mockResolvedValue({
       serviceSlug: "stripe",
@@ -65,6 +73,9 @@ describe("service page", () => {
     expect(html).toContain("Token refresh requires browser redirect in some flows");
     expect(html).toContain("href=\"/service/square\"");
     expect(html).toContain("square</a> (7.4)");
+    expect(html).toContain("application/ld+json");
+    expect(html).toContain('"@type":"SoftwareApplication"');
+    expect(html).toContain('"name":"stripe"');
     expect(notFoundMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- implement homepage hero with search entry and resilient top-payments leaderboard preview
- add machine-discovery baseline export in `app/llms.txt` and refresh web README route map
- add JSON-LD structured data + `generateMetadata` baselines on leaderboard and service pages
- add/extend page tests for homepage fallback behavior and metadata assertions

## Testing
- cd packages/web && npm run test
- cd packages/web && npm run type-check
