### PR TITLE
R8 Slice B: Core MCP tools (find_tools, get_score) with API integration

### DIFF
--- a/packages/mcp/src/api-client.ts
+++ b/packages/mcp/src/api-client.ts
@@ -1,0 +1,128 @@
+/**
+ * Rhumb MCP Server — API Client
+ *
+ * Lightweight client for the Rhumb REST API.
+ * Follows the same parsing patterns as the web package adapters.
+ */
+
+// ---------------------------------------------------------------------------
+// Shared result types (used by tool handlers)
+// ---------------------------------------------------------------------------
+
+export interface ServiceSearchItem {
+  name: string;
+  slug: string;
+  aggregateScore: number | null;
+  executionScore: number | null;
+  accessScore: number | null;
+  explanation: string;
+}
+
+export interface ServiceScoreItem {
+  slug: string;
+  aggregateScore: number | null;
+  executionScore: number | null;
+  accessScore: number | null;
+  confidence: number;
+  tier: string;
+  explanation: string;
+  freshness: string;
+}
+
+// ---------------------------------------------------------------------------
+// Client interface (for dependency injection / testing)
+// ---------------------------------------------------------------------------
+
+export interface RhumbApiClient {
+  searchServices(query: string): Promise<ServiceSearchItem[]>;
+  getServiceScore(slug: string): Promise<ServiceScoreItem | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Parse helpers (mirrors web/lib/adapters.ts patterns)
+// ---------------------------------------------------------------------------
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function asNumber(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createApiClient(baseUrl?: string): RhumbApiClient {
+  const base = baseUrl ?? process.env.RHUMB_API_BASE_URL ?? "http://localhost:8000/v1";
+
+  return {
+    async searchServices(query: string): Promise<ServiceSearchItem[]> {
+      const url = `${base}/services?query=${encodeURIComponent(query)}`;
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error(`API returned ${res.status}`);
+      }
+
+      const payload: unknown = await res.json();
+      if (!isRecord(payload) || !isRecord(payload.data)) {
+        return [];
+      }
+
+      const items = Array.isArray(payload.data.items) ? payload.data.items : [];
+
+      return items
+        .filter((item: unknown): item is Record<string, unknown> => isRecord(item))
+        .map((item) => ({
+          name: asString(item.name) ?? asString(item.slug) ?? "unknown",
+          slug: asString(item.slug) ?? "unknown",
+          aggregateScore: asNumber(item.aggregate_recommendation_score),
+          executionScore: asNumber(item.execution_score),
+          accessScore: asNumber(item.access_readiness_score),
+          explanation: asString(item.explanation) ?? ""
+        }))
+        .filter((item) => item.slug !== "unknown");
+    },
+
+    async getServiceScore(slug: string): Promise<ServiceScoreItem | null> {
+      const url = `${base}/services/${encodeURIComponent(slug)}/score`;
+      const res = await fetch(url);
+
+      if (!res.ok) {
+        if (res.status === 404) return null;
+        throw new Error(`API returned ${res.status}`);
+      }
+
+      const payload: unknown = await res.json();
+      if (!isRecord(payload)) return null;
+
+      const serviceSlug = asString(payload.service_slug);
+      if (!serviceSlug) return null;
+
+      const snapshot = isRecord(payload.dimension_snapshot)
+        ? payload.dimension_snapshot
+        : {};
+
+      return {
+        slug: serviceSlug,
+        aggregateScore: asNumber(payload.aggregate_recommendation_score),
+        executionScore: asNumber(payload.execution_score),
+        accessScore: asNumber(payload.access_readiness_score),
+        confidence: asNumber(payload.confidence) ?? 0,
+        tier: asString(payload.tier) ?? "unknown",
+        explanation: asString(payload.explanation) ?? "",
+        freshness:
+          asString(snapshot.probe_freshness) ??
+          asString(snapshot.freshness) ??
+          asString(snapshot.evidence_freshness) ??
+          asString(payload.probe_freshness) ??
+          "unknown"
+      };
+    }
+  };
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -11,12 +11,19 @@ import {
   GetAlternativesInputSchema,
   GetFailureModesInputSchema
 } from "./types.js";
+import { createApiClient, type RhumbApiClient } from "./api-client.js";
+import { handleFindTools } from "./tools/find.js";
+import { handleGetScore } from "./tools/score.js";
 
 /**
  * Creates and configures the Rhumb MCP server with all tool registrations.
- * Tool handlers are stubs in Slice A — real implementations come in Slices B/C.
+ *
+ * @param apiClient Optional API client override (for testing). Uses default
+ *                  createApiClient() when omitted.
  */
-export function createServer(): McpServer {
+export function createServer(apiClient?: RhumbApiClient): McpServer {
+  const client = apiClient ?? createApiClient();
+
   const server = new McpServer({
     name: "rhumb",
     version: "0.0.1"
@@ -31,9 +38,9 @@ export function createServer(): McpServer {
       limit: z.number().min(1).max(50).optional().describe(FindToolInputSchema.properties.limit.description)
     },
     async ({ query, limit }) => {
-      // Stub — Slice B implements real handler
+      const result = await handleFindTools({ query, limit }, client);
       return {
-        content: [{ type: "text" as const, text: JSON.stringify({ tools: [] }) }]
+        content: [{ type: "text" as const, text: JSON.stringify(result) }]
       };
     }
   );
@@ -46,9 +53,9 @@ export function createServer(): McpServer {
       slug: z.string().describe(GetScoreInputSchema.properties.slug.description)
     },
     async ({ slug }) => {
-      // Stub — Slice B implements real handler
+      const result = await handleGetScore({ slug }, client);
       return {
-        content: [{ type: "text" as const, text: JSON.stringify({ slug, aggregateScore: null, executionScore: null, accessScore: null, confidence: 0, tier: "unknown", explanation: "Not yet implemented", freshness: "unknown" }) }]
+        content: [{ type: "text" as const, text: JSON.stringify(result) }]
       };
     }
   );

--- a/packages/mcp/src/tools/find.ts
+++ b/packages/mcp/src/tools/find.ts
@@ -1,0 +1,52 @@
+/**
+ * find_tools — Semantic search for agent tools, ranked by AN Score
+ *
+ * Calls the Rhumb API to search services and returns results
+ * sorted by aggregateScore descending.
+ */
+
+import type { FindToolInput, FindToolOutput } from "../types.js";
+import type { RhumbApiClient } from "../api-client.js";
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+
+/**
+ * Handle a find_tools request.
+ *
+ * @param input  Validated tool input (query + optional limit)
+ * @param client API client for fetching services
+ * @returns      Ranked tool results; empty array on any error (resilient)
+ */
+export async function handleFindTools(
+  input: FindToolInput,
+  client: RhumbApiClient
+): Promise<FindToolOutput> {
+  const limit = Math.min(Math.max(input.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+
+  try {
+    const services = await client.searchServices(input.query);
+
+    // Sort by aggregateScore descending — nulls sink to bottom
+    const sorted = [...services].sort((a, b) => {
+      if (a.aggregateScore === null && b.aggregateScore === null) return 0;
+      if (a.aggregateScore === null) return 1;
+      if (b.aggregateScore === null) return -1;
+      return b.aggregateScore - a.aggregateScore;
+    });
+
+    return {
+      tools: sorted.slice(0, limit).map((s) => ({
+        name: s.name,
+        slug: s.slug,
+        aggregateScore: s.aggregateScore,
+        executionScore: s.executionScore,
+        accessScore: s.accessScore,
+        explanation: s.explanation
+      }))
+    };
+  } catch {
+    // Resilient fallback: return empty array on any error
+    return { tools: [] };
+  }
+}

--- a/packages/mcp/src/tools/score.ts
+++ b/packages/mcp/src/tools/score.ts
@@ -1,0 +1,52 @@
+/**
+ * get_score — Detailed AN Score breakdown for a single service
+ *
+ * Calls the Rhumb API to fetch the full score breakdown
+ * for the specified service slug.
+ */
+
+import type { GetScoreInput, GetScoreOutput } from "../types.js";
+import type { RhumbApiClient } from "../api-client.js";
+
+/**
+ * Handle a get_score request.
+ *
+ * @param input  Validated tool input (slug)
+ * @param client API client for fetching the score
+ * @returns      Full score breakdown; error response with message on failure
+ */
+export async function handleGetScore(
+  input: GetScoreInput,
+  client: RhumbApiClient
+): Promise<GetScoreOutput> {
+  try {
+    const score = await client.getServiceScore(input.slug);
+
+    if (!score) {
+      return {
+        slug: input.slug,
+        aggregateScore: null,
+        executionScore: null,
+        accessScore: null,
+        confidence: 0,
+        tier: "unknown",
+        explanation: `Service '${input.slug}' not found`,
+        freshness: "unknown"
+      };
+    }
+
+    return score;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      slug: input.slug,
+      aggregateScore: null,
+      executionScore: null,
+      accessScore: null,
+      confidence: 0,
+      tier: "unknown",
+      explanation: `Failed to fetch score: ${message}`,
+      freshness: "unknown"
+    };
+  }
+}

--- a/packages/mcp/tests/tools/find.tool.test.ts
+++ b/packages/mcp/tests/tools/find.tool.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleFindTools } from "../../src/tools/find.js";
+import type { RhumbApiClient, ServiceSearchItem } from "../../src/api-client.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockServices: ServiceSearchItem[] = [
+  {
+    name: "SendGrid",
+    slug: "sendgrid",
+    aggregateScore: 82,
+    executionScore: 85,
+    accessScore: 79,
+    explanation: "Reliable email API with strong SDK support"
+  },
+  {
+    name: "Mailgun",
+    slug: "mailgun",
+    aggregateScore: 78,
+    executionScore: 80,
+    accessScore: 76,
+    explanation: "Good email delivery with flexible pricing"
+  },
+  {
+    name: "Resend",
+    slug: "resend",
+    aggregateScore: 91,
+    executionScore: 93,
+    accessScore: 89,
+    explanation: "Modern email API with excellent DX"
+  },
+  {
+    name: "Postmark",
+    slug: "postmark",
+    aggregateScore: 85,
+    executionScore: 88,
+    accessScore: 82,
+    explanation: "Fast transactional email delivery"
+  },
+  {
+    name: "Experimental Mail",
+    slug: "experimental-mail",
+    aggregateScore: null,
+    executionScore: null,
+    accessScore: null,
+    explanation: "New service, not yet scored"
+  }
+];
+
+function createMockClient(
+  services: ServiceSearchItem[] = mockServices
+): RhumbApiClient {
+  return {
+    searchServices: vi.fn().mockResolvedValue(services),
+    getServiceScore: vi.fn().mockResolvedValue(null)
+  };
+}
+
+function createErrorClient(): RhumbApiClient {
+  return {
+    searchServices: vi.fn().mockRejectedValue(new Error("Network failure")),
+    getServiceScore: vi.fn().mockRejectedValue(new Error("Network failure"))
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("find_tools handler", () => {
+  it("returns results ranked by aggregateScore descending", async () => {
+    const client = createMockClient();
+    const result = await handleFindTools({ query: "email" }, client);
+
+    expect(result.tools.length).toBeGreaterThan(0);
+    expect(client.searchServices).toHaveBeenCalledWith("email");
+
+    // Verify descending order (nulls at end)
+    for (let i = 0; i < result.tools.length - 1; i++) {
+      const current = result.tools[i].aggregateScore;
+      const next = result.tools[i + 1].aggregateScore;
+      if (current !== null && next !== null) {
+        expect(current).toBeGreaterThanOrEqual(next);
+      }
+      if (current === null) {
+        expect(next).toBeNull();
+      }
+    }
+
+    // First result should be highest scored
+    expect(result.tools[0].slug).toBe("resend");
+    expect(result.tools[0].aggregateScore).toBe(91);
+  });
+
+  it("clamps limit to MAX_LIMIT (50) and MIN (1)", async () => {
+    const client = createMockClient();
+
+    // Limit = 2 should return only 2
+    const result = await handleFindTools({ query: "email", limit: 2 }, client);
+    expect(result.tools).toHaveLength(2);
+    expect(result.tools[0].slug).toBe("resend");
+    expect(result.tools[1].slug).toBe("postmark");
+
+    // Limit = 0 should clamp to 1
+    const result2 = await handleFindTools({ query: "email", limit: 0 }, client);
+    expect(result2.tools).toHaveLength(1);
+
+    // Limit = 100 should clamp to 50 (but we only have 5 items)
+    const result3 = await handleFindTools({ query: "email", limit: 100 }, client);
+    expect(result3.tools).toHaveLength(5);
+  });
+
+  it("defaults limit to 10 when not provided", async () => {
+    const client = createMockClient();
+    const result = await handleFindTools({ query: "email" }, client);
+
+    // We have 5 items, default limit is 10, so all 5 returned
+    expect(result.tools).toHaveLength(5);
+    expect(client.searchServices).toHaveBeenCalledWith("email");
+  });
+
+  it("returns empty array when API returns no results", async () => {
+    const client = createMockClient([]);
+    const result = await handleFindTools({ query: "nonexistent" }, client);
+
+    expect(result.tools).toEqual([]);
+    expect(client.searchServices).toHaveBeenCalledWith("nonexistent");
+  });
+
+  it("returns empty array on API error (resilient fallback)", async () => {
+    const client = createErrorClient();
+    const result = await handleFindTools({ query: "email" }, client);
+
+    expect(result.tools).toEqual([]);
+  });
+
+  it("includes all required output fields per tool", async () => {
+    const client = createMockClient();
+    const result = await handleFindTools({ query: "email", limit: 1 }, client);
+
+    const tool = result.tools[0];
+    expect(tool).toHaveProperty("name");
+    expect(tool).toHaveProperty("slug");
+    expect(tool).toHaveProperty("aggregateScore");
+    expect(tool).toHaveProperty("executionScore");
+    expect(tool).toHaveProperty("accessScore");
+    expect(tool).toHaveProperty("explanation");
+  });
+
+  it("null scores sort to the end", async () => {
+    const client = createMockClient();
+    const result = await handleFindTools({ query: "email" }, client);
+
+    // "experimental-mail" has null score — should be last
+    const lastTool = result.tools[result.tools.length - 1];
+    expect(lastTool.slug).toBe("experimental-mail");
+    expect(lastTool.aggregateScore).toBeNull();
+  });
+});

--- a/packages/mcp/tests/tools/score.tool.test.ts
+++ b/packages/mcp/tests/tools/score.tool.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleGetScore } from "../../src/tools/score.js";
+import type { RhumbApiClient, ServiceScoreItem } from "../../src/api-client.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockScoreResponse: ServiceScoreItem = {
+  slug: "sendgrid",
+  aggregateScore: 82,
+  executionScore: 85,
+  accessScore: 79,
+  confidence: 0.95,
+  tier: "ready",
+  explanation: "Reliable email API with strong SDK support and mature documentation",
+  freshness: "2026-03-01T00:00:00Z"
+};
+
+function createMockClient(
+  score: ServiceScoreItem | null = mockScoreResponse
+): RhumbApiClient {
+  return {
+    searchServices: vi.fn().mockResolvedValue([]),
+    getServiceScore: vi.fn().mockResolvedValue(score)
+  };
+}
+
+function createErrorClient(): RhumbApiClient {
+  return {
+    searchServices: vi.fn().mockResolvedValue([]),
+    getServiceScore: vi.fn().mockRejectedValue(new Error("API returned 500"))
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("get_score handler", () => {
+  it("returns full score breakdown for a valid slug", async () => {
+    const client = createMockClient();
+    const result = await handleGetScore({ slug: "sendgrid" }, client);
+
+    expect(client.getServiceScore).toHaveBeenCalledWith("sendgrid");
+    expect(result).toEqual({
+      slug: "sendgrid",
+      aggregateScore: 82,
+      executionScore: 85,
+      accessScore: 79,
+      confidence: 0.95,
+      tier: "ready",
+      explanation: "Reliable email API with strong SDK support and mature documentation",
+      freshness: "2026-03-01T00:00:00Z"
+    });
+  });
+
+  it("includes all required output fields", async () => {
+    const client = createMockClient();
+    const result = await handleGetScore({ slug: "sendgrid" }, client);
+
+    expect(result).toHaveProperty("slug");
+    expect(result).toHaveProperty("aggregateScore");
+    expect(result).toHaveProperty("executionScore");
+    expect(result).toHaveProperty("accessScore");
+    expect(result).toHaveProperty("confidence");
+    expect(result).toHaveProperty("tier");
+    expect(result).toHaveProperty("explanation");
+    expect(result).toHaveProperty("freshness");
+  });
+
+  it("returns error response for 404 (service not found)", async () => {
+    const client = createMockClient(null);
+    const result = await handleGetScore({ slug: "nonexistent-service" }, client);
+
+    expect(result.slug).toBe("nonexistent-service");
+    expect(result.aggregateScore).toBeNull();
+    expect(result.executionScore).toBeNull();
+    expect(result.accessScore).toBeNull();
+    expect(result.confidence).toBe(0);
+    expect(result.tier).toBe("unknown");
+    expect(result.explanation).toContain("nonexistent-service");
+    expect(result.explanation).toContain("not found");
+    expect(result.freshness).toBe("unknown");
+  });
+
+  it("returns error response on API error (resilient fallback)", async () => {
+    const client = createErrorClient();
+    const result = await handleGetScore({ slug: "sendgrid" }, client);
+
+    expect(result.slug).toBe("sendgrid");
+    expect(result.aggregateScore).toBeNull();
+    expect(result.confidence).toBe(0);
+    expect(result.tier).toBe("unknown");
+    expect(result.explanation).toContain("Failed to fetch score");
+    expect(result.explanation).toContain("API returned 500");
+    expect(result.freshness).toBe("unknown");
+  });
+
+  it("does not throw on API error", async () => {
+    const client = createErrorClient();
+
+    // Should not throw — returns error response instead
+    await expect(
+      handleGetScore({ slug: "sendgrid" }, client)
+    ).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Round 8 — Slice B: Core Tools

Implements the two core MCP tool handlers with full API integration and resilient fallbacks.

### What's new

**`src/tools/find.ts`** — `find_tools` handler
- Calls `/v1/services?query=` via injected API client
- Results ranked by `aggregateScore` descending (nulls sink to bottom)
- Limit clamped to [1, 50], defaults to 10
- Resilient: returns empty array on any API error

**`src/tools/score.ts`** — `get_score` handler
- Calls `/v1/services/{slug}/score` via injected API client
- Returns full score breakdown (aggregate, execution, access, confidence, tier, explanation, freshness)
- 404 → structured error response with explicit "not found" message
- API error → structured error response with error message (never crashes)

**`src/api-client.ts`** — Lightweight API client
- `RhumbApiClient` interface for dependency injection
- `createApiClient(baseUrl?)` factory using `fetch`
- Parsing follows web package adapter patterns (safe coercions)
- Configurable via `RHUMB_API_BASE_URL` env var

**`src/server.ts`** — Updated tool registration
- Imports and wires real handlers for `find_tools` and `get_score`
- `createServer(apiClient?)` accepts optional client override for testing
- Slice C stubs (`get_alternatives`, `get_failure_modes`) preserved

### Acceptance criteria
- ✅ All tests pass — 17/17 (7 Slice A + 12 Slice B: 7 find + 5 score)
- ✅ Type-check passes (zero errors)
- ✅ No regressions in Slice A tests
- ✅ Zero linting errors
