### PR TITLE
R8 Slice C: Related tools (get_alternatives, get_failure_modes)

### DIFF
--- a/packages/mcp/src/api-client.ts
+++ b/packages/mcp/src/api-client.ts
@@ -18,6 +18,14 @@ export interface ServiceSearchItem {
   explanation: string;
 }
 
+export interface FailureModeItem {
+  pattern: string;
+  impact: string;
+  frequency: string;
+  workaround: string;
+  tags: string[];
+}
+
 export interface ServiceScoreItem {
   slug: string;
   aggregateScore: number | null;
@@ -27,6 +35,8 @@ export interface ServiceScoreItem {
   tier: string;
   explanation: string;
   freshness: string;
+  failureModes: FailureModeItem[];
+  tags: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -108,6 +118,31 @@ export function createApiClient(baseUrl?: string): RhumbApiClient {
         ? payload.dimension_snapshot
         : {};
 
+      // Parse failure_modes array from API response
+      const rawFailures = Array.isArray(payload.failure_modes)
+        ? payload.failure_modes
+        : [];
+
+      const failureModes: FailureModeItem[] = rawFailures
+        .filter((fm: unknown): fm is Record<string, unknown> => isRecord(fm))
+        .map((fm) => ({
+          pattern: asString(fm.pattern) ?? "unknown",
+          impact: asString(fm.impact) ?? "unknown",
+          frequency: asString(fm.frequency) ?? "unknown",
+          workaround: asString(fm.workaround) ?? "none",
+          tags: Array.isArray(fm.tags)
+            ? (fm.tags as unknown[]).filter((t): t is string => typeof t === "string")
+            : []
+        }));
+
+      // Collect unique tags from all failure modes
+      const tagSet = new Set<string>();
+      for (const fm of failureModes) {
+        for (const tag of fm.tags) {
+          tagSet.add(tag);
+        }
+      }
+
       return {
         slug: serviceSlug,
         aggregateScore: asNumber(payload.aggregate_recommendation_score),
@@ -121,7 +156,9 @@ export function createApiClient(baseUrl?: string): RhumbApiClient {
           asString(snapshot.freshness) ??
           asString(snapshot.evidence_freshness) ??
           asString(payload.probe_freshness) ??
-          "unknown"
+          "unknown",
+        failureModes,
+        tags: [...tagSet]
       };
     }
   };

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,6 +14,8 @@ import {
 import { createApiClient, type RhumbApiClient } from "./api-client.js";
 import { handleFindTools } from "./tools/find.js";
 import { handleGetScore } from "./tools/score.js";
+import { handleGetAlternatives } from "./tools/alternatives.js";
+import { handleGetFailureModes } from "./tools/failures.js";
 
 /**
  * Creates and configures the Rhumb MCP server with all tool registrations.
@@ -68,9 +70,9 @@ export function createServer(apiClient?: RhumbApiClient): McpServer {
       slug: z.string().describe(GetAlternativesInputSchema.properties.slug.description)
     },
     async ({ slug }) => {
-      // Stub — Slice C implements real handler
+      const result = await handleGetAlternatives({ slug }, client);
       return {
-        content: [{ type: "text" as const, text: JSON.stringify({ alternatives: [] }) }]
+        content: [{ type: "text" as const, text: JSON.stringify(result) }]
       };
     }
   );
@@ -83,9 +85,9 @@ export function createServer(apiClient?: RhumbApiClient): McpServer {
       slug: z.string().describe(GetFailureModesInputSchema.properties.slug.description)
     },
     async ({ slug }) => {
-      // Stub — Slice C implements real handler
+      const result = await handleGetFailureModes({ slug }, client);
       return {
-        content: [{ type: "text" as const, text: JSON.stringify({ failures: [] }) }]
+        content: [{ type: "text" as const, text: JSON.stringify(result) }]
       };
     }
   );

--- a/packages/mcp/src/tools/alternatives.ts
+++ b/packages/mcp/src/tools/alternatives.ts
@@ -1,0 +1,60 @@
+/**
+ * get_alternatives — Find alternative services ranked by AN Score
+ *
+ * Extracts failure-mode tags from the current service's score response,
+ * searches for peer services sharing those tags, and returns peers
+ * with higher aggregateScore ranked descending.
+ */
+
+import type { GetAlternativesInput, GetAlternativesOutput } from "../types.js";
+import type { RhumbApiClient } from "../api-client.js";
+
+/**
+ * Handle a get_alternatives request.
+ *
+ * @param input  Validated tool input (slug)
+ * @param client API client for fetching services
+ * @returns      Ranked alternative services; empty array on any error (resilient)
+ */
+export async function handleGetAlternatives(
+  input: GetAlternativesInput,
+  client: RhumbApiClient
+): Promise<GetAlternativesOutput> {
+  try {
+    const score = await client.getServiceScore(input.slug);
+    if (!score) return { alternatives: [] };
+
+    const tags = score.tags;
+    if (tags.length === 0) return { alternatives: [] };
+
+    // Search for peer services using each failure tag
+    const searchPromises = tags.map((tag) => client.searchServices(tag));
+    const results = await Promise.all(searchPromises);
+    const allPeers = results.flat();
+
+    // Deduplicate, exclude current service, filter to higher scores
+    const currentScore = score.aggregateScore ?? 0;
+    const seen = new Set<string>();
+    const sharedTags = tags.join(", ");
+
+    const alternatives = allPeers
+      .filter((peer) => {
+        if (peer.slug === input.slug) return false;
+        if (seen.has(peer.slug)) return false;
+        seen.add(peer.slug);
+        return (peer.aggregateScore ?? 0) > currentScore;
+      })
+      .sort((a, b) => (b.aggregateScore ?? 0) - (a.aggregateScore ?? 0))
+      .map((peer) => ({
+        name: peer.name,
+        slug: peer.slug,
+        aggregateScore: peer.aggregateScore,
+        reason: `Higher AN Score alternative (shared failure patterns: ${sharedTags})`
+      }));
+
+    return { alternatives };
+  } catch {
+    // Resilient fallback: return empty array on any error
+    return { alternatives: [] };
+  }
+}

--- a/packages/mcp/src/tools/failures.ts
+++ b/packages/mcp/src/tools/failures.ts
@@ -1,0 +1,38 @@
+/**
+ * get_failure_modes — Known failure patterns for a service
+ *
+ * Calls the Rhumb API to fetch the service score and extracts
+ * the failure_modes array, mapping each to the output contract.
+ */
+
+import type { GetFailureModesInput, GetFailureModesOutput } from "../types.js";
+import type { RhumbApiClient } from "../api-client.js";
+
+/**
+ * Handle a get_failure_modes request.
+ *
+ * @param input  Validated tool input (slug)
+ * @param client API client for fetching the service score
+ * @returns      Failure modes array; empty array on any error (resilient)
+ */
+export async function handleGetFailureModes(
+  input: GetFailureModesInput,
+  client: RhumbApiClient
+): Promise<GetFailureModesOutput> {
+  try {
+    const score = await client.getServiceScore(input.slug);
+    if (!score) return { failures: [] };
+
+    return {
+      failures: score.failureModes.map((fm) => ({
+        pattern: fm.pattern,
+        impact: fm.impact,
+        frequency: fm.frequency,
+        workaround: fm.workaround
+      }))
+    };
+  } catch {
+    // Resilient fallback: return empty array on any error
+    return { failures: [] };
+  }
+}

--- a/packages/mcp/tests/tools/alternatives.tool.test.ts
+++ b/packages/mcp/tests/tools/alternatives.tool.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleGetAlternatives } from "../../src/tools/alternatives.js";
+import type {
+  RhumbApiClient,
+  ServiceScoreItem,
+  ServiceSearchItem
+} from "../../src/api-client.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockScoreWithTags: ServiceScoreItem = {
+  slug: "sendgrid",
+  aggregateScore: 72,
+  executionScore: 75,
+  accessScore: 69,
+  confidence: 0.9,
+  tier: "ready",
+  explanation: "Reliable but aging email API",
+  freshness: "2026-03-01T00:00:00Z",
+  failureModes: [
+    {
+      pattern: "Rate limit exceeded",
+      impact: "Emails delayed or dropped",
+      frequency: "moderate",
+      workaround: "Implement exponential backoff",
+      tags: ["rate-limiting", "email-delivery"]
+    },
+    {
+      pattern: "Webhook delivery failure",
+      impact: "Lost event notifications",
+      frequency: "low",
+      workaround: "Use polling as fallback",
+      tags: ["webhooks"]
+    }
+  ],
+  tags: ["rate-limiting", "email-delivery", "webhooks"]
+};
+
+const peerServices: ServiceSearchItem[] = [
+  {
+    name: "Resend",
+    slug: "resend",
+    aggregateScore: 91,
+    executionScore: 93,
+    accessScore: 89,
+    explanation: "Modern email API with excellent DX"
+  },
+  {
+    name: "Postmark",
+    slug: "postmark",
+    aggregateScore: 85,
+    executionScore: 88,
+    accessScore: 82,
+    explanation: "Fast transactional email delivery"
+  },
+  {
+    name: "Mailgun",
+    slug: "mailgun",
+    aggregateScore: 68,
+    executionScore: 70,
+    accessScore: 66,
+    explanation: "Flexible email with lower score"
+  },
+  {
+    name: "SendGrid",
+    slug: "sendgrid",
+    aggregateScore: 72,
+    executionScore: 75,
+    accessScore: 69,
+    explanation: "The service itself (should be excluded)"
+  }
+];
+
+function createMockClient(
+  score: ServiceScoreItem | null = mockScoreWithTags,
+  searchResults: ServiceSearchItem[] = peerServices
+): RhumbApiClient {
+  return {
+    searchServices: vi.fn().mockResolvedValue(searchResults),
+    getServiceScore: vi.fn().mockResolvedValue(score)
+  };
+}
+
+function createErrorClient(): RhumbApiClient {
+  return {
+    searchServices: vi.fn().mockRejectedValue(new Error("Network failure")),
+    getServiceScore: vi.fn().mockRejectedValue(new Error("Network failure"))
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("get_alternatives handler", () => {
+  it("returns alternatives ranked by aggregateScore descending", async () => {
+    const client = createMockClient();
+    const result = await handleGetAlternatives({ slug: "sendgrid" }, client);
+
+    expect(client.getServiceScore).toHaveBeenCalledWith("sendgrid");
+    expect(result.alternatives.length).toBeGreaterThan(0);
+
+    // Verify descending order
+    for (let i = 0; i < result.alternatives.length - 1; i++) {
+      const current = result.alternatives[i].aggregateScore ?? 0;
+      const next = result.alternatives[i + 1].aggregateScore ?? 0;
+      expect(current).toBeGreaterThanOrEqual(next);
+    }
+
+    // First alternative should be highest-scored peer
+    expect(result.alternatives[0].slug).toBe("resend");
+    expect(result.alternatives[0].aggregateScore).toBe(91);
+  });
+
+  it("only includes peers with higher aggregateScore than the current service", async () => {
+    const client = createMockClient();
+    const result = await handleGetAlternatives({ slug: "sendgrid" }, client);
+
+    // sendgrid has score 72 — only resend (91) and postmark (85) should appear
+    // mailgun (68) is lower, sendgrid itself is excluded
+    const slugs = result.alternatives.map((a) => a.slug);
+    expect(slugs).toContain("resend");
+    expect(slugs).toContain("postmark");
+    expect(slugs).not.toContain("mailgun");
+    expect(slugs).not.toContain("sendgrid");
+  });
+
+  it("excludes the current service from alternatives", async () => {
+    const client = createMockClient();
+    const result = await handleGetAlternatives({ slug: "sendgrid" }, client);
+
+    const slugs = result.alternatives.map((a) => a.slug);
+    expect(slugs).not.toContain("sendgrid");
+  });
+
+  it("deduplicates peers found across multiple tag searches", async () => {
+    // The service has 3 tags, so searchServices is called 3 times
+    // Each call returns the same peers — should be deduplicated
+    const client = createMockClient();
+    const result = await handleGetAlternatives({ slug: "sendgrid" }, client);
+
+    const slugs = result.alternatives.map((a) => a.slug);
+    const uniqueSlugs = new Set(slugs);
+    expect(slugs.length).toBe(uniqueSlugs.size);
+  });
+
+  it("includes reason with shared failure pattern tags", async () => {
+    const client = createMockClient();
+    const result = await handleGetAlternatives({ slug: "sendgrid" }, client);
+
+    for (const alt of result.alternatives) {
+      expect(alt.reason).toContain("shared failure patterns");
+      expect(alt).toHaveProperty("name");
+      expect(alt).toHaveProperty("slug");
+      expect(alt).toHaveProperty("aggregateScore");
+    }
+  });
+
+  it("returns empty array when service has no failure tags", async () => {
+    const scoreNoTags: ServiceScoreItem = {
+      ...mockScoreWithTags,
+      failureModes: [],
+      tags: []
+    };
+    const client = createMockClient(scoreNoTags);
+    const result = await handleGetAlternatives({ slug: "sendgrid" }, client);
+
+    expect(result.alternatives).toEqual([]);
+  });
+
+  it("returns empty array when service is not found (404)", async () => {
+    const client = createMockClient(null);
+    const result = await handleGetAlternatives({ slug: "nonexistent" }, client);
+
+    expect(result.alternatives).toEqual([]);
+  });
+
+  it("returns empty array on API error (resilient fallback)", async () => {
+    const client = createErrorClient();
+    const result = await handleGetAlternatives({ slug: "sendgrid" }, client);
+
+    expect(result.alternatives).toEqual([]);
+  });
+
+  it("returns empty array when no peers have higher scores", async () => {
+    // All peers have lower scores than the current service
+    const highScore: ServiceScoreItem = {
+      ...mockScoreWithTags,
+      aggregateScore: 99
+    };
+    const client = createMockClient(highScore);
+    const result = await handleGetAlternatives({ slug: "sendgrid" }, client);
+
+    expect(result.alternatives).toEqual([]);
+  });
+});

--- a/packages/mcp/tests/tools/failures.tool.test.ts
+++ b/packages/mcp/tests/tools/failures.tool.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleGetFailureModes } from "../../src/tools/failures.js";
+import type {
+  RhumbApiClient,
+  ServiceScoreItem,
+  FailureModeItem
+} from "../../src/api-client.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockFailureModes: FailureModeItem[] = [
+  {
+    pattern: "Rate limit exceeded on burst sends",
+    impact: "Emails delayed or silently dropped during peak traffic",
+    frequency: "moderate",
+    workaround: "Implement exponential backoff with jitter",
+    tags: ["rate-limiting", "email-delivery"]
+  },
+  {
+    pattern: "Webhook delivery failure on HTTPS endpoints",
+    impact: "Lost event notifications for bounces and opens",
+    frequency: "low",
+    workaround: "Use polling as fallback; configure retry policy",
+    tags: ["webhooks"]
+  },
+  {
+    pattern: "API key rotation causes temporary auth failures",
+    impact: "503 errors during key propagation window (~30s)",
+    frequency: "rare",
+    workaround: "Support dual active keys during rotation",
+    tags: ["auth", "key-management"]
+  }
+];
+
+const mockScoreWithFailures: ServiceScoreItem = {
+  slug: "sendgrid",
+  aggregateScore: 82,
+  executionScore: 85,
+  accessScore: 79,
+  confidence: 0.95,
+  tier: "ready",
+  explanation: "Reliable email API",
+  freshness: "2026-03-01T00:00:00Z",
+  failureModes: mockFailureModes,
+  tags: ["rate-limiting", "email-delivery", "webhooks", "auth", "key-management"]
+};
+
+function createMockClient(
+  score: ServiceScoreItem | null = mockScoreWithFailures
+): RhumbApiClient {
+  return {
+    searchServices: vi.fn().mockResolvedValue([]),
+    getServiceScore: vi.fn().mockResolvedValue(score)
+  };
+}
+
+function createErrorClient(): RhumbApiClient {
+  return {
+    searchServices: vi.fn().mockResolvedValue([]),
+    getServiceScore: vi.fn().mockRejectedValue(new Error("API returned 500"))
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("get_failure_modes handler", () => {
+  it("extracts and maps failure modes from score response", async () => {
+    const client = createMockClient();
+    const result = await handleGetFailureModes({ slug: "sendgrid" }, client);
+
+    expect(client.getServiceScore).toHaveBeenCalledWith("sendgrid");
+    expect(result.failures).toHaveLength(3);
+
+    expect(result.failures[0]).toEqual({
+      pattern: "Rate limit exceeded on burst sends",
+      impact: "Emails delayed or silently dropped during peak traffic",
+      frequency: "moderate",
+      workaround: "Implement exponential backoff with jitter"
+    });
+
+    expect(result.failures[1]).toEqual({
+      pattern: "Webhook delivery failure on HTTPS endpoints",
+      impact: "Lost event notifications for bounces and opens",
+      frequency: "low",
+      workaround: "Use polling as fallback; configure retry policy"
+    });
+
+    expect(result.failures[2]).toEqual({
+      pattern: "API key rotation causes temporary auth failures",
+      impact: "503 errors during key propagation window (~30s)",
+      frequency: "rare",
+      workaround: "Support dual active keys during rotation"
+    });
+  });
+
+  it("includes all required output fields per failure mode", async () => {
+    const client = createMockClient();
+    const result = await handleGetFailureModes({ slug: "sendgrid" }, client);
+
+    for (const failure of result.failures) {
+      expect(failure).toHaveProperty("pattern");
+      expect(failure).toHaveProperty("impact");
+      expect(failure).toHaveProperty("frequency");
+      expect(failure).toHaveProperty("workaround");
+      expect(typeof failure.pattern).toBe("string");
+      expect(typeof failure.impact).toBe("string");
+      expect(typeof failure.frequency).toBe("string");
+      expect(typeof failure.workaround).toBe("string");
+    }
+  });
+
+  it("does not include internal tags in the output", async () => {
+    const client = createMockClient();
+    const result = await handleGetFailureModes({ slug: "sendgrid" }, client);
+
+    for (const failure of result.failures) {
+      expect(failure).not.toHaveProperty("tags");
+    }
+  });
+
+  it("returns empty array when service has no failure modes", async () => {
+    const scoreNoFailures: ServiceScoreItem = {
+      ...mockScoreWithFailures,
+      failureModes: [],
+      tags: []
+    };
+    const client = createMockClient(scoreNoFailures);
+    const result = await handleGetFailureModes({ slug: "sendgrid" }, client);
+
+    expect(result.failures).toEqual([]);
+  });
+
+  it("returns empty array when service is not found (404)", async () => {
+    const client = createMockClient(null);
+    const result = await handleGetFailureModes({ slug: "nonexistent" }, client);
+
+    expect(result.failures).toEqual([]);
+  });
+
+  it("returns empty array on API error (resilient fallback)", async () => {
+    const client = createErrorClient();
+    const result = await handleGetFailureModes({ slug: "sendgrid" }, client);
+
+    expect(result.failures).toEqual([]);
+  });
+
+  it("does not throw on API error", async () => {
+    const client = createErrorClient();
+
+    await expect(
+      handleGetFailureModes({ slug: "sendgrid" }, client)
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/mcp/tests/tools/score.tool.test.ts
+++ b/packages/mcp/tests/tools/score.tool.test.ts
@@ -14,7 +14,9 @@ const mockScoreResponse: ServiceScoreItem = {
   confidence: 0.95,
   tier: "ready",
   explanation: "Reliable email API with strong SDK support and mature documentation",
-  freshness: "2026-03-01T00:00:00Z"
+  freshness: "2026-03-01T00:00:00Z",
+  failureModes: [],
+  tags: []
 };
 
 function createMockClient(
@@ -51,7 +53,9 @@ describe("get_score handler", () => {
       confidence: 0.95,
       tier: "ready",
       explanation: "Reliable email API with strong SDK support and mature documentation",
-      freshness: "2026-03-01T00:00:00Z"
+      freshness: "2026-03-01T00:00:00Z",
+      failureModes: [],
+      tags: []
     });
   });
 


### PR DESCRIPTION
## Summary

Round 8 Slice C — implements the two related-data tool handlers for the MCP server.

### Changes

**New files:**
- `src/tools/alternatives.ts` — `get_alternatives` handler: extracts failure-mode tags from a service's score, searches for peer services sharing those tags with higher AN Scores, returns ranked alternatives
- `src/tools/failures.ts` — `get_failure_modes` handler: extracts failure_modes array from the score endpoint and maps to output contract (pattern, impact, frequency, workaround)
- `tests/tools/alternatives.tool.test.ts` — 9 tests covering ranking, dedup, exclusion, tag matching, empty/error fallbacks
- `tests/tools/failures.tool.test.ts` — 7 tests covering extraction, mapping, shape validation, empty/error fallbacks

**Modified files:**
- `src/api-client.ts` — extended `ServiceScoreItem` with `failureModes` and `tags` fields; added `FailureModeItem` interface; updated parser to extract `failure_modes` from API response
- `src/server.ts` — replaced stubs with real handler imports and wiring for both tools
- `tests/tools/score.tool.test.ts` — updated mock fixtures to include new required fields

### Acceptance Criteria
- ✅ All 33 tests pass (16 new for Slice C, 17 existing from A + B)
- ✅ Type-check passes (`tsc --noEmit` clean)
- ✅ Zero regressions in Slice A + B tests
- ✅ Zero linting errors
- ✅ Resilient fallback (empty arrays) on API errors for both handlers