### PR TITLE
mcp: integration docs and end-to-end test (R8 Slice D)

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -20,14 +20,49 @@ npm install
 npx tsx src/index.ts
 ```
 
-## Framework Integration
+## Claude Desktop
+
+Get started with Claude Desktop in under 5 minutes:
+
+1. Build the server: `cd packages/mcp && npm run build`
+2. Add the server to `claude_desktop_config.json`
+3. Restart Claude Desktop
+
+📖 **Full guide:** [docs/CLAUDE-DEV.md](docs/CLAUDE-DEV.md)
+
+## Integration
+
+For architecture details, tool contracts, handler development, testing patterns, and deployment options:
+
+📖 **[MCP Integration Guide](docs/MCP-INTEGRATION.md)**
+
+### Framework links
 
 - [Anthropic Claude SDK](https://docs.anthropic.com/en/docs/agents-and-tools/mcp)
 - [LangChain MCP Adapters](https://github.com/langchain-ai/langchain-mcp-adapters)
 - [CrewAI](https://docs.crewai.com/)
 - [AutoGen](https://microsoft.github.io/autogen/)
 
-> Full installation guides: see `docs/FRAMEWORK-INSTALL.md` (Slice D).
+## Testing
+
+The test suite is organized into three layers:
+
+| Layer | Files | What it covers |
+|-------|-------|----------------|
+| **Contract** | `tests/types.contract.test.ts` | JSON Schema validity, TypeScript type compliance |
+| **Unit** | `tests/server.init.test.ts`, `tests/tools/*.test.ts` | Server init, individual handler logic with mock API clients |
+| **E2E** | `tests/e2e.server.test.ts` | Full server instance → tool call → response via MCP protocol |
+
+```bash
+# Run all tests
+npm run test
+
+# Run specific test file
+npx vitest run tests/e2e.server.test.ts
+
+# Run with verbose output
+npx vitest run --reporter=verbose
+```
 
 ## Development
 
@@ -47,4 +82,7 @@ npm run build
 - `src/index.ts` — Entry point, stdio transport
 - `src/types.ts` — Tool I/O contracts (JSON Schema + TypeScript types)
 - `src/server.ts` — Server initialization + tool registration
-- `tests/` — Contract and initialization tests
+- `src/api-client.ts` — Rhumb API client (DI-compatible interface)
+- `src/tools/` — Tool handler implementations
+- `tests/` — Contract, unit, and end-to-end tests
+- `docs/` — Integration and framework guides

--- a/packages/mcp/docs/CLAUDE-DEV.md
+++ b/packages/mcp/docs/CLAUDE-DEV.md
@@ -1,0 +1,186 @@
+# Using the Rhumb MCP Server with Claude Desktop
+
+This guide walks you through installing and configuring the Rhumb MCP server for use with [Claude Desktop](https://claude.ai/download).
+
+## Prerequisites
+
+- **Node.js** ≥ 18 (LTS recommended)
+- **Claude Desktop** installed ([download](https://claude.ai/download))
+- **Git** (to clone the repo)
+
+## Installation
+
+```bash
+# 1. Clone the Rhumb repository
+git clone https://github.com/supertrained/rhumb.git
+cd rhumb
+
+# 2. Install dependencies
+npm install
+
+# 3. Build the MCP server package
+cd packages/mcp
+npm run build
+```
+
+Verify the build succeeded:
+
+```bash
+ls dist/index.js  # should exist after build
+```
+
+## Configuration
+
+Claude Desktop discovers MCP servers through its configuration file.
+
+### Locate the config file
+
+| Platform | Path |
+|----------|------|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+
+### Add the Rhumb server
+
+Open `claude_desktop_config.json` and add an entry under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "rhumb": {
+      "command": "node",
+      "args": ["/absolute/path/to/rhumb/packages/mcp/dist/index.js"],
+      "env": {
+        "RHUMB_API_BASE_URL": "https://api.rhumb.dev/v1"
+      }
+    }
+  }
+}
+```
+
+> **Note:** Replace `/absolute/path/to/rhumb` with the actual path to your cloned repository.
+
+#### Using `tsx` for development
+
+During development you can skip the build step and run TypeScript directly:
+
+```json
+{
+  "mcpServers": {
+    "rhumb": {
+      "command": "npx",
+      "args": ["tsx", "/absolute/path/to/rhumb/packages/mcp/src/index.ts"],
+      "env": {
+        "RHUMB_API_BASE_URL": "http://localhost:8000/v1"
+      }
+    }
+  }
+}
+```
+
+### Restart Claude Desktop
+
+After saving the config, restart Claude Desktop. You should see "rhumb" listed in the MCP tools panel (click the 🔌 icon in the input area).
+
+## Example Usage
+
+Once configured, you can invoke Rhumb tools directly from Claude:
+
+### Find tools
+
+> "Find the best email delivery APIs for my agent"
+
+Claude will call `find_tools` with your query and return AN Score–ranked results:
+
+```
+Tools found:
+1. Resend (slug: resend) — AN Score: 91
+   Modern email API with excellent DX
+2. Postmark (slug: postmark) — AN Score: 85
+   Fast transactional email delivery
+3. SendGrid (slug: sendgrid) — AN Score: 82
+   Reliable email API with strong SDK support
+```
+
+### Get detailed score
+
+> "What's the AN Score breakdown for sendgrid?"
+
+Claude calls `get_score` and returns the full breakdown:
+
+```
+SendGrid (sendgrid)
+  Aggregate: 82 | Execution: 85 | Access: 79
+  Confidence: 0.95 | Tier: ready
+  Freshness: 2026-03-01
+```
+
+### Find alternatives
+
+> "What are better alternatives to sendgrid?"
+
+Claude calls `get_alternatives` to find higher-scored peers:
+
+```
+Alternatives to sendgrid (score: 72):
+1. Resend (91) — Higher AN Score alternative
+2. Postmark (85) — Higher AN Score alternative
+```
+
+### Get failure modes
+
+> "What are the known failure modes for sendgrid?"
+
+Claude calls `get_failure_modes` to extract failure patterns:
+
+```
+Failure modes for sendgrid:
+1. Rate limit exceeded on burst sends
+   Impact: Emails delayed or dropped | Frequency: moderate
+   Workaround: Implement exponential backoff with jitter
+```
+
+## Debugging
+
+### Check server logs
+
+Claude Desktop logs MCP server output. Find logs at:
+
+| Platform | Path |
+|----------|------|
+| macOS | `~/Library/Logs/Claude/mcp*.log` |
+| Windows | `%APPDATA%\Claude\logs\mcp*.log` |
+
+### Common issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Server not listed in Claude | Config syntax error | Validate JSON in `claude_desktop_config.json` |
+| "Connection refused" errors | API not reachable | Check `RHUMB_API_BASE_URL` and network |
+| Tools return empty results | API key / auth issue | Verify API credentials if required |
+| Server crashes on start | Missing dependencies | Run `npm install` in `packages/mcp` |
+| TypeScript errors with `tsx` | Wrong Node.js version | Use Node.js ≥ 18 |
+
+### Manual testing
+
+You can test the server independently via stdio:
+
+```bash
+# Start the server
+cd packages/mcp
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | npx tsx src/index.ts
+```
+
+This should output a JSON response listing all 4 registered tools.
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RHUMB_API_BASE_URL` | `http://localhost:8000/v1` | Rhumb API base URL |
+
+## Transport
+
+The Rhumb MCP server uses **stdio transport** — Claude Desktop communicates with it via stdin/stdout. This is the standard MCP transport for local servers and requires no network port configuration.
+
+For remote/HTTP transport options, see [MCP-INTEGRATION.md](./MCP-INTEGRATION.md#deployment).

--- a/packages/mcp/docs/MCP-INTEGRATION.md
+++ b/packages/mcp/docs/MCP-INTEGRATION.md
@@ -1,0 +1,370 @@
+# MCP Server Integration Guide
+
+Technical guide for integrating with, extending, and deploying the Rhumb MCP server.
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────┐
+│                    MCP Client                        │
+│  (Claude Desktop, LangChain, CrewAI, custom agent)   │
+└──────────────────────┬───────────────────────────────┘
+                       │  stdio / HTTP (JSON-RPC 2.0)
+┌──────────────────────▼───────────────────────────────┐
+│               Rhumb MCP Server                       │
+│  src/server.ts — createServer(apiClient?)             │
+│                                                      │
+│  ┌────────────┐ ┌───────────┐ ┌─────────────────┐   │
+│  │ find_tools │ │ get_score │ │get_alternatives │   │
+│  └─────┬──────┘ └─────┬─────┘ └───────┬─────────┘   │
+│  ┌─────▼──────────────▼───────────────▼─────────┐   │
+│  │           get_failure_modes                   │   │
+│  └─────────────────────┬─────────────────────────┘   │
+│                        │                             │
+│  ┌─────────────────────▼─────────────────────────┐   │
+│  │        RhumbApiClient (DI interface)           │   │
+│  │  searchServices(query) → ServiceSearchItem[]   │   │
+│  │  getServiceScore(slug) → ServiceScoreItem|null │   │
+│  └─────────────────────┬─────────────────────────┘   │
+└────────────────────────┼─────────────────────────────┘
+                         │  HTTP (fetch)
+┌────────────────────────▼─────────────────────────────┐
+│                 Rhumb REST API                       │
+│  GET /v1/services?query=...                          │
+│  GET /v1/services/{slug}/score                       │
+└──────────────────────────────────────────────────────┘
+```
+
+### Key patterns
+
+- **Tool registration:** Each tool is registered via `server.tool(name, description, zodSchema, handler)` using the MCP SDK's `McpServer` class.
+- **Handler pattern:** Tool handlers are pure async functions in `src/tools/*.ts`. They receive validated input and an `RhumbApiClient` instance — no direct SDK coupling.
+- **Dependency injection:** `createServer(apiClient?)` accepts an optional `RhumbApiClient`. Production uses the default HTTP client; tests inject mocks.
+
+## Tool Contracts
+
+### `find_tools`
+
+Semantic search for agent tools, ranked by AN Score.
+
+**Input:**
+```typescript
+{
+  query: string;    // Search query (required)
+  limit?: number;   // Max results, 1–50, default 10
+}
+```
+
+**Output:**
+```typescript
+{
+  tools: Array<{
+    name: string;
+    slug: string;
+    aggregateScore: number | null;
+    executionScore: number | null;
+    accessScore: number | null;
+    explanation: string;
+  }>
+}
+```
+
+**Error behavior:** Returns `{ tools: [] }` on any API error (resilient fallback).
+
+---
+
+### `get_score`
+
+Detailed AN Score breakdown for a single service.
+
+**Input:**
+```typescript
+{
+  slug: string;  // Service identifier (required)
+}
+```
+
+**Output:**
+```typescript
+{
+  slug: string;
+  aggregateScore: number | null;
+  executionScore: number | null;
+  accessScore: number | null;
+  confidence: number;
+  tier: string;
+  explanation: string;
+  freshness: string;
+}
+```
+
+**Error behavior:** Returns a valid response with `tier: "unknown"` and descriptive `explanation` on API error or 404. Never throws.
+
+---
+
+### `get_alternatives`
+
+Find alternative services with higher AN Scores, based on shared failure-mode tags.
+
+**Input:**
+```typescript
+{
+  slug: string;  // Service to find alternatives for (required)
+}
+```
+
+**Output:**
+```typescript
+{
+  alternatives: Array<{
+    name: string;
+    slug: string;
+    aggregateScore: number | null;
+    reason: string;
+  }>
+}
+```
+
+**Error behavior:** Returns `{ alternatives: [] }` on any error (resilient fallback).
+
+---
+
+### `get_failure_modes`
+
+Known failure patterns for a service.
+
+**Input:**
+```typescript
+{
+  slug: string;  // Service identifier (required)
+}
+```
+
+**Output:**
+```typescript
+{
+  failures: Array<{
+    pattern: string;
+    impact: string;
+    frequency: string;
+    workaround: string;
+  }>
+}
+```
+
+**Error behavior:** Returns `{ failures: [] }` on any error (resilient fallback).
+
+## Handler Development Guide
+
+To add a new tool to the Rhumb MCP server:
+
+### 1. Define the contract
+
+Add input/output schemas and types to `src/types.ts`:
+
+```typescript
+// src/types.ts
+export const GetMyToolInputSchema = {
+  type: "object" as const,
+  properties: {
+    param: { type: "string" as const, description: "Parameter description" }
+  },
+  required: ["param"] as const
+};
+
+export type GetMyToolInput = {
+  param: string;
+};
+
+export type GetMyToolOutput = {
+  result: string;
+};
+```
+
+Update `TOOL_SCHEMAS` and `TOOL_NAMES` in the same file.
+
+### 2. Implement the handler
+
+Create `src/tools/my-tool.ts`:
+
+```typescript
+import type { GetMyToolInput, GetMyToolOutput } from "../types.js";
+import type { RhumbApiClient } from "../api-client.js";
+
+export async function handleGetMyTool(
+  input: GetMyToolInput,
+  client: RhumbApiClient
+): Promise<GetMyToolOutput> {
+  try {
+    // Your logic here, using client for API calls
+    return { result: "value" };
+  } catch {
+    // Resilient fallback — never throw
+    return { result: "" };
+  }
+}
+```
+
+**Handler rules:**
+- Accept `(input, client)` — keep handlers pure and testable
+- Always wrap API calls in try/catch — return a valid fallback, never throw
+- Return types must match the output contract exactly
+
+### 3. Register the tool
+
+Add registration to `src/server.ts`:
+
+```typescript
+import { handleGetMyTool } from "./tools/my-tool.js";
+
+// Inside createServer():
+server.tool(
+  "my_tool",
+  "Description of what the tool does",
+  { param: z.string().describe("Parameter description") },
+  async ({ param }) => {
+    const result = await handleGetMyTool({ param }, client);
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(result) }]
+    };
+  }
+);
+```
+
+### 4. Add API methods (if needed)
+
+If your tool needs new API endpoints, extend the `RhumbApiClient` interface in `src/api-client.ts` and implement the method in `createApiClient()`.
+
+### 5. Write tests
+
+See [Testing Patterns](#testing-patterns) below.
+
+## Testing Patterns
+
+### Mock client setup
+
+All tool tests use mock `RhumbApiClient` instances:
+
+```typescript
+import { vi } from "vitest";
+import type { RhumbApiClient } from "../../src/api-client.js";
+
+function createMockClient(): RhumbApiClient {
+  return {
+    searchServices: vi.fn().mockResolvedValue([
+      { name: "Example", slug: "example", aggregateScore: 85,
+        executionScore: 90, accessScore: 80, explanation: "Test service" }
+    ]),
+    getServiceScore: vi.fn().mockResolvedValue({
+      slug: "example", aggregateScore: 85, executionScore: 90,
+      accessScore: 80, confidence: 0.9, tier: "ready",
+      explanation: "Test", freshness: "2026-03-01",
+      failureModes: [], tags: []
+    })
+  };
+}
+
+function createErrorClient(): RhumbApiClient {
+  return {
+    searchServices: vi.fn().mockRejectedValue(new Error("Network failure")),
+    getServiceScore: vi.fn().mockRejectedValue(new Error("Network failure"))
+  };
+}
+```
+
+### Test categories
+
+| Category | Location | What it tests |
+|----------|----------|---------------|
+| Contract tests | `tests/types.contract.test.ts` | Schema validity, type correctness |
+| Init tests | `tests/server.init.test.ts` | Server boots, tools registered |
+| Tool unit tests | `tests/tools/*.tool.test.ts` | Handler logic with mock API client |
+| E2E tests | `tests/e2e.server.test.ts` | Full server → tool call → response flow |
+
+### What to test for each handler
+
+1. **Happy path** — correct output shape with valid input
+2. **Required output fields** — all contract fields present
+3. **API error resilience** — returns fallback, never throws
+4. **Edge cases** — empty results, null scores, missing data
+5. **No side effects** — no unintended API calls or mutations
+
+### Running tests
+
+```bash
+cd packages/mcp
+
+# Run all tests
+npm run test
+
+# Run with verbose output
+npx vitest run --reporter=verbose
+
+# Run a specific test file
+npx vitest run tests/e2e.server.test.ts
+```
+
+## Deployment
+
+### stdio transport (default)
+
+The default transport. The MCP client spawns the server as a child process and communicates over stdin/stdout.
+
+```bash
+# Production
+node dist/index.js
+
+# Development
+npx tsx src/index.ts
+```
+
+**Advantages:** Simple, no port management, process-level isolation.
+**Use when:** Running locally with Claude Desktop or any stdio-compatible MCP client.
+
+### HTTP transport (SSE)
+
+For remote or multi-client deployments, the MCP SDK supports HTTP with Server-Sent Events:
+
+```typescript
+// src/index-http.ts (example — not included in default build)
+import express from "express";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { createServer } from "./server.js";
+
+const app = express();
+const mcpServer = createServer();
+
+app.get("/sse", async (req, res) => {
+  const transport = new SSEServerTransport("/messages", res);
+  await mcpServer.connect(transport);
+});
+
+app.post("/messages", async (req, res) => {
+  // Handle incoming messages
+});
+
+app.listen(3001, () => {
+  console.log("Rhumb MCP server (HTTP) listening on :3001");
+});
+```
+
+**Advantages:** Network-accessible, supports multiple simultaneous clients.
+**Use when:** Deploying as a shared service, remote access needed, or multi-agent scenarios.
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RHUMB_API_BASE_URL` | `http://localhost:8000/v1` | Base URL for the Rhumb REST API |
+
+### Docker (future)
+
+```dockerfile
+FROM node:22-slim
+WORKDIR /app
+COPY packages/mcp/ .
+RUN npm ci && npm run build
+CMD ["node", "dist/index.js"]
+```
+
+> **Note:** Docker deployment is not yet officially supported but follows standard Node.js container patterns.

--- a/packages/mcp/tests/e2e.server.test.ts
+++ b/packages/mcp/tests/e2e.server.test.ts
@@ -1,0 +1,353 @@
+/**
+ * End-to-end integration tests for the Rhumb MCP Server.
+ *
+ * These tests create a real MCP server instance via createServer() with a
+ * mock API client, then invoke each registered tool through the server's
+ * internal handler pipeline — verifying the full registration → dispatch →
+ * handler → response chain.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { createServer } from "../src/server.js";
+import type {
+  RhumbApiClient,
+  ServiceSearchItem,
+  ServiceScoreItem,
+} from "../src/api-client.js";
+import type { FindToolOutput, GetScoreOutput, GetAlternativesOutput, GetFailureModesOutput } from "../src/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock API client fixtures
+// ---------------------------------------------------------------------------
+
+const mockServices: ServiceSearchItem[] = [
+  {
+    name: "Resend",
+    slug: "resend",
+    aggregateScore: 91,
+    executionScore: 93,
+    accessScore: 89,
+    explanation: "Modern email API with excellent DX",
+  },
+  {
+    name: "Postmark",
+    slug: "postmark",
+    aggregateScore: 85,
+    executionScore: 88,
+    accessScore: 82,
+    explanation: "Fast transactional email delivery",
+  },
+  {
+    name: "SendGrid",
+    slug: "sendgrid",
+    aggregateScore: 72,
+    executionScore: 75,
+    accessScore: 69,
+    explanation: "Reliable email API",
+  },
+];
+
+const mockScore: ServiceScoreItem = {
+  slug: "resend",
+  aggregateScore: 91,
+  executionScore: 93,
+  accessScore: 89,
+  confidence: 0.97,
+  tier: "excellent",
+  explanation: "Modern email API with excellent DX",
+  freshness: "2026-03-01T00:00:00Z",
+  failureModes: [
+    {
+      pattern: "SDK timeout on large batch sends",
+      impact: "Batch emails may fail silently above 500 recipients",
+      frequency: "low",
+      workaround: "Split batches into chunks of 100",
+      tags: ["batch-sending", "timeout"],
+    },
+  ],
+  tags: ["batch-sending", "timeout"],
+};
+
+function createMockApiClient(): RhumbApiClient {
+  return {
+    searchServices: vi.fn().mockResolvedValue(mockServices),
+    getServiceScore: vi.fn().mockImplementation(async (slug: string) => {
+      if (slug === "resend") return mockScore;
+      if (slug === "nonexistent") return null;
+      return { ...mockScore, slug };
+    }),
+  };
+}
+
+function createErrorApiClient(): RhumbApiClient {
+  return {
+    searchServices: vi
+      .fn()
+      .mockRejectedValue(new Error("API connection refused")),
+    getServiceScore: vi
+      .fn()
+      .mockRejectedValue(new Error("API connection refused")),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: connect MCP client ↔ server via in-memory transport
+// ---------------------------------------------------------------------------
+
+async function createConnectedClient(apiClient: RhumbApiClient) {
+  const server = createServer(apiClient);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+
+  await Promise.all([
+    client.connect(clientTransport),
+    server.connect(serverTransport),
+  ]);
+
+  return { client, server };
+}
+
+/**
+ * Extract the JSON text from a callTool result.
+ * callTool returns `{ [x: string]: unknown; content: ... }` — the index
+ * signature makes `content` resolve to `unknown` under strict mode.
+ * We use the validated result schema to work around this safely.
+ */
+function extractText(result: Awaited<ReturnType<Client["callTool"]>>): string {
+  const content = result.content as Array<{ type: string; text?: string }>;
+  const first = content[0];
+  if (!first || first.type !== "text" || typeof first.text !== "string") {
+    throw new Error("Expected text content in tool result");
+  }
+  return first.text;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("e2e: MCP server integration", () => {
+  describe("tool registration", () => {
+    it("lists all 4 registered tools", async () => {
+      const apiClient = createMockApiClient();
+      const { client } = await createConnectedClient(apiClient);
+
+      const { tools } = await client.listTools();
+      const toolNames = tools.map((t) => t.name).sort();
+
+      expect(toolNames).toEqual([
+        "find_tools",
+        "get_alternatives",
+        "get_failure_modes",
+        "get_score",
+      ]);
+      expect(tools).toHaveLength(4);
+
+      // Each tool has a description and input schema
+      for (const tool of tools) {
+        expect(tool.description).toBeTruthy();
+        expect(tool.inputSchema).toBeDefined();
+      }
+    });
+  });
+
+  describe("find_tools", () => {
+    it("returns ranked results with correct output shape", async () => {
+      const apiClient = createMockApiClient();
+      const { client } = await createConnectedClient(apiClient);
+
+      const result = await client.callTool({
+        name: "find_tools",
+        arguments: { query: "email delivery", limit: 3 },
+      }, CallToolResultSchema);
+
+      const parsed: FindToolOutput = JSON.parse(extractText(result));
+      expect(parsed.tools.length).toBeGreaterThan(0);
+      expect(parsed.tools.length).toBeLessThanOrEqual(3);
+
+      // Verify ranking — first result should have highest score
+      expect(parsed.tools[0].slug).toBe("resend");
+      expect(parsed.tools[0].aggregateScore).toBe(91);
+
+      // Verify output shape
+      for (const tool of parsed.tools) {
+        expect(tool).toHaveProperty("name");
+        expect(tool).toHaveProperty("slug");
+        expect(tool).toHaveProperty("aggregateScore");
+        expect(tool).toHaveProperty("executionScore");
+        expect(tool).toHaveProperty("accessScore");
+        expect(tool).toHaveProperty("explanation");
+      }
+
+      expect(apiClient.searchServices).toHaveBeenCalledWith("email delivery");
+    });
+  });
+
+  describe("get_score", () => {
+    it("returns full breakdown with correct fields", async () => {
+      const apiClient = createMockApiClient();
+      const { client } = await createConnectedClient(apiClient);
+
+      const result = await client.callTool({
+        name: "get_score",
+        arguments: { slug: "resend" },
+      }, CallToolResultSchema);
+
+      const parsed: GetScoreOutput = JSON.parse(extractText(result));
+
+      expect(parsed.slug).toBe("resend");
+      expect(parsed.aggregateScore).toBe(91);
+      expect(parsed.executionScore).toBe(93);
+      expect(parsed.accessScore).toBe(89);
+      expect(parsed.confidence).toBe(0.97);
+      expect(parsed.tier).toBe("excellent");
+      expect(parsed.explanation).toBeTruthy();
+      expect(parsed.freshness).toBeTruthy();
+    });
+  });
+
+  describe("get_alternatives", () => {
+    it("returns peer-ranked alternatives", async () => {
+      const apiClient = createMockApiClient();
+      const { client } = await createConnectedClient(apiClient);
+
+      // Use sendgrid (score 72) — resend (91) and postmark (85) should appear
+      // Override getServiceScore to return sendgrid's score
+      (apiClient.getServiceScore as ReturnType<typeof vi.fn>).mockImplementation(
+        async (slug: string) => {
+          if (slug === "sendgrid")
+            return {
+              ...mockScore,
+              slug: "sendgrid",
+              aggregateScore: 72,
+              executionScore: 75,
+              accessScore: 69,
+            };
+          return null;
+        }
+      );
+
+      const result = await client.callTool({
+        name: "get_alternatives",
+        arguments: { slug: "sendgrid" },
+      }, CallToolResultSchema);
+
+      const parsed: GetAlternativesOutput = JSON.parse(extractText(result));
+
+      expect(parsed.alternatives.length).toBeGreaterThan(0);
+
+      // Verify output shape
+      for (const alt of parsed.alternatives) {
+        expect(alt).toHaveProperty("name");
+        expect(alt).toHaveProperty("slug");
+        expect(alt).toHaveProperty("aggregateScore");
+        expect(alt).toHaveProperty("reason");
+      }
+
+      // All alternatives should have higher score than sendgrid (72)
+      for (const alt of parsed.alternatives) {
+        expect(alt.aggregateScore).toBeGreaterThan(72);
+      }
+    });
+  });
+
+  describe("get_failure_modes", () => {
+    it("returns failure patterns with correct structure", async () => {
+      const apiClient = createMockApiClient();
+      const { client } = await createConnectedClient(apiClient);
+
+      const result = await client.callTool({
+        name: "get_failure_modes",
+        arguments: { slug: "resend" },
+      }, CallToolResultSchema);
+
+      const parsed: GetFailureModesOutput = JSON.parse(extractText(result));
+
+      expect(parsed.failures.length).toBeGreaterThan(0);
+
+      for (const failure of parsed.failures) {
+        expect(failure).toHaveProperty("pattern");
+        expect(failure).toHaveProperty("impact");
+        expect(failure).toHaveProperty("frequency");
+        expect(failure).toHaveProperty("workaround");
+        expect(typeof failure.pattern).toBe("string");
+        expect(typeof failure.impact).toBe("string");
+        // Should NOT expose internal tags
+        expect(failure).not.toHaveProperty("tags");
+      }
+
+      expect(parsed.failures[0].pattern).toBe(
+        "SDK timeout on large batch sends"
+      );
+    });
+  });
+
+  describe("error handling and resilience", () => {
+    it("handles API errors gracefully without crashing", async () => {
+      const apiClient = createErrorApiClient();
+      const { client } = await createConnectedClient(apiClient);
+
+      // find_tools — should return empty tools, not throw
+      const findResult = await client.callTool({
+        name: "find_tools",
+        arguments: { query: "email" },
+      }, CallToolResultSchema);
+      const findParsed: FindToolOutput = JSON.parse(extractText(findResult));
+      expect(findParsed.tools).toEqual([]);
+
+      // get_score — should return error response, not throw
+      const scoreResult = await client.callTool({
+        name: "get_score",
+        arguments: { slug: "sendgrid" },
+      }, CallToolResultSchema);
+      const scoreParsed: GetScoreOutput = JSON.parse(extractText(scoreResult));
+      expect(scoreParsed.slug).toBe("sendgrid");
+      expect(scoreParsed.tier).toBe("unknown");
+      expect(scoreParsed.explanation).toContain("Failed to fetch score");
+
+      // get_alternatives — should return empty alternatives
+      const altResult = await client.callTool({
+        name: "get_alternatives",
+        arguments: { slug: "sendgrid" },
+      }, CallToolResultSchema);
+      const altParsed: GetAlternativesOutput = JSON.parse(extractText(altResult));
+      expect(altParsed.alternatives).toEqual([]);
+
+      // get_failure_modes — should return empty failures
+      const failResult = await client.callTool({
+        name: "get_failure_modes",
+        arguments: { slug: "sendgrid" },
+      }, CallToolResultSchema);
+      const failParsed: GetFailureModesOutput = JSON.parse(extractText(failResult));
+      expect(failParsed.failures).toEqual([]);
+    });
+
+    it("handles missing/not-found service gracefully", async () => {
+      const apiClient = createMockApiClient();
+      const { client } = await createConnectedClient(apiClient);
+
+      // get_score with nonexistent slug
+      const scoreResult = await client.callTool({
+        name: "get_score",
+        arguments: { slug: "nonexistent" },
+      }, CallToolResultSchema);
+      const scoreParsed: GetScoreOutput = JSON.parse(extractText(scoreResult));
+      expect(scoreParsed.slug).toBe("nonexistent");
+      expect(scoreParsed.aggregateScore).toBeNull();
+      expect(scoreParsed.tier).toBe("unknown");
+      expect(scoreParsed.explanation).toContain("not found");
+
+      // get_failure_modes with nonexistent slug
+      const failResult = await client.callTool({
+        name: "get_failure_modes",
+        arguments: { slug: "nonexistent" },
+      }, CallToolResultSchema);
+      const failParsed: GetFailureModesOutput = JSON.parse(extractText(failResult));
+      expect(failParsed.failures).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Round 8 — Slice D: Framework Integration Docs + E2E Test

### What
- **`docs/CLAUDE-DEV.md`** — Step-by-step Claude Desktop integration guide (prerequisites, installation, configuration, example usage, debugging)
- **`docs/MCP-INTEGRATION.md`** — General MCP server guide (architecture overview, tool contracts, handler development guide, testing patterns, deployment options)
- **`tests/e2e.server.test.ts`** — 7 end-to-end tests using real MCP client ↔ server via InMemoryTransport
- **`README.md`** — Updated with Integration, Claude Desktop, and Testing sections

### Acceptance Criteria
- ✅ E2E tests pass: 7 tests (exceeds 5+ requirement)
- ✅ All tests pass cumulatively: **40 total** (33 unit + 7 e2e)
- ✅ Type-check passes (zero errors)
- ✅ Zero linting errors
- ✅ Documentation is clear and complete (both frameworks covered)
- ✅ No regressions in unit tests

### E2E Test Coverage
1. Tool registration — all 4 tools listed via MCP protocol
2. `find_tools` — ranked results with correct output shape
3. `get_score` — full breakdown with all fields
4. `get_alternatives` — peer-ranked alternatives
5. `get_failure_modes` — failure patterns with correct structure
6. Error handling — API errors return fallbacks, no crashes
7. Resilience — missing/not-found services handled gracefully

### Test Output
```
 ✓ tests/types.contract.test.ts  (3 tests)
 ✓ tests/tools/find.tool.test.ts  (7 tests)
 ✓ tests/tools/score.tool.test.ts  (5 tests)
 ✓ tests/tools/alternatives.tool.test.ts  (9 tests)
 ✓ tests/tools/failures.tool.test.ts  (7 tests)
 ✓ tests/server.init.test.ts  (2 tests)
 ✓ tests/e2e.server.test.ts  (7 tests)

 Test Files  7 passed (7)
      Tests  40 passed (40)
```

Closes Round 8.