### PR TITLE
feat: Round 12 — Metering + Billing Pipeline

### DIFF
--- a/packages/api/app.py
+++ b/packages/api/app.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 
 from routes import (
     admin_agents,
+    admin_billing,
     leaderboard,
     probes,
     proxy,
@@ -26,6 +27,9 @@ def create_app() -> FastAPI:
     application.include_router(proxy.router, prefix="/v1/proxy", tags=["proxy"])
     application.include_router(
         admin_agents.router, prefix="/v1/admin", tags=["admin-agents"]
+    )
+    application.include_router(
+        admin_billing.router, prefix="/v1", tags=["admin-billing"]
     )
 
     @application.get("/healthz")

--- a/packages/api/migrations/0006_metering_billing.sql
+++ b/packages/api/migrations/0006_metering_billing.sql
@@ -1,0 +1,29 @@
+-- Round 12 (WU 2.3): Metering + Billing pipeline
+
+-- Extend usage events with payload size for billing analytics.
+ALTER TABLE agent_usage_events
+ADD COLUMN IF NOT EXISTS response_size_bytes BIGINT DEFAULT 0;
+
+-- Organization-level invoices.
+CREATE TABLE IF NOT EXISTS invoices (
+    invoice_id UUID PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    month TEXT NOT NULL,
+    subtotal DECIMAL(12, 6) NOT NULL,
+    tax DECIMAL(12, 6) NOT NULL,
+    total DECIMAL(12, 6) NOT NULL,
+    status TEXT NOT NULL DEFAULT 'draft',
+    stripe_invoice_id TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    due_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    UNIQUE (organization_id, month)
+);
+
+-- Organization billing fields.
+ALTER TABLE organizations
+ADD COLUMN IF NOT EXISTS stripe_customer_id TEXT,
+ADD COLUMN IF NOT EXISTS monthly_spend_cap_usd DECIMAL(12, 2) DEFAULT 100.0;
+
+-- Invoice query performance indexes.
+CREATE INDEX IF NOT EXISTS idx_invoices_org_month ON invoices (organization_id, month);
+CREATE INDEX IF NOT EXISTS idx_invoices_status ON invoices (status);

--- a/packages/api/routes/admin_billing.py
+++ b/packages/api/routes/admin_billing.py
@@ -1,0 +1,180 @@
+"""Admin billing routes for metering, invoices, and forecasting."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from services.billing_aggregation import BillingAggregator, get_billing_aggregator
+from services.stripe_integration import (
+    StripeIntegrationManager,
+    get_stripe_integration_manager,
+)
+from services.usage_metering import COST_PER_CALL_USD, UsageMeterEngine, get_usage_meter_engine
+
+router = APIRouter(tags=["admin-billing"])
+
+
+class GenerateInvoiceRequest(BaseModel):
+    """Request payload for invoice generation."""
+
+    organization_id: str = Field(...)
+    month: str = Field(..., description="Month in YYYY-MM format")
+
+
+_test_usage_meter: Optional[UsageMeterEngine] = None
+_test_billing_aggregator: Optional[BillingAggregator] = None
+_test_stripe_manager: Optional[StripeIntegrationManager] = None
+
+
+def set_test_billing_stores(
+    usage_meter: Optional[UsageMeterEngine] = None,
+    billing_aggregator: Optional[BillingAggregator] = None,
+    stripe_manager: Optional[StripeIntegrationManager] = None,
+) -> None:
+    """Inject test stores (call with ``None`` to reset)."""
+    global _test_usage_meter, _test_billing_aggregator, _test_stripe_manager
+    _test_usage_meter = usage_meter
+    _test_billing_aggregator = billing_aggregator
+    _test_stripe_manager = stripe_manager
+
+
+def _get_usage_meter() -> UsageMeterEngine:
+    return _test_usage_meter or get_usage_meter_engine()
+
+
+def _get_billing_aggregator() -> BillingAggregator:
+    return _test_billing_aggregator or get_billing_aggregator()
+
+
+def _get_stripe_manager() -> StripeIntegrationManager:
+    return _test_stripe_manager or get_stripe_integration_manager()
+
+
+@router.get("/admin/billing/usage")
+async def get_usage_report(
+    organization_id: str = Query(...),
+    month: str = Query(..., description="Month in YYYY-MM format"),
+) -> Dict[str, Any]:
+    """Return organization monthly usage report."""
+    usage_meter = _get_usage_meter()
+    usage = await usage_meter.get_org_monthly_usage(organization_id, month)
+
+    return {
+        "organization_id": usage.organization_id,
+        "month": usage.month,
+        "total_calls": usage.total_calls,
+        "cost_estimate": usage.cost_estimate,
+        "by_service": {
+            service: {
+                "call_count": summary.call_count,
+                "cost_estimate": summary.cost_estimate,
+            }
+            for service, summary in usage.by_service.items()
+        },
+        "by_agent": {
+            agent_id: {
+                "total_calls": summary.total_calls,
+                "cost_estimate": summary.cost_estimate,
+            }
+            for agent_id, summary in usage.by_agent.items()
+        },
+    }
+
+
+@router.get("/admin/billing/invoices")
+async def list_invoices(organization_id: str = Query(...)) -> List[Dict[str, Any]]:
+    """List invoices for one organization."""
+    aggregator = _get_billing_aggregator()
+    invoices = aggregator.list_invoices(organization_id)
+
+    return [
+        {
+            "invoice_id": invoice.invoice_id,
+            "organization_id": invoice.organization_id,
+            "month": invoice.month,
+            "subtotal": invoice.subtotal,
+            "tax": invoice.tax,
+            "total": invoice.total,
+            "status": invoice.status,
+            "created_at": invoice.created_at.isoformat(),
+            "due_at": invoice.due_at.isoformat(),
+        }
+        for invoice in invoices
+    ]
+
+
+@router.post("/admin/billing/invoices/generate")
+async def generate_invoice(body: GenerateInvoiceRequest) -> Dict[str, Any]:
+    """Generate a draft invoice for organization + month."""
+    aggregator = _get_billing_aggregator()
+    invoice = await aggregator.generate_invoice(body.organization_id, body.month)
+
+    return {
+        "invoice_id": invoice.invoice_id,
+        "organization_id": invoice.organization_id,
+        "month": invoice.month,
+        "subtotal": invoice.subtotal,
+        "tax": invoice.tax,
+        "total": invoice.total,
+        "status": invoice.status,
+        "line_items": [
+            {
+                "service": line.service,
+                "call_count": line.call_count,
+                "unit_cost": line.unit_cost,
+                "total_cost": line.total_cost,
+            }
+            for line in invoice.line_items
+        ],
+    }
+
+
+@router.post("/admin/billing/invoices/{invoice_id}/send")
+async def send_invoice(invoice_id: str) -> Dict[str, Any]:
+    """Send an invoice by creating a payment intent and marking it sent."""
+    aggregator = _get_billing_aggregator()
+    stripe_manager = _get_stripe_manager()
+
+    invoice = aggregator.get_invoice(invoice_id)
+    if invoice is None:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+
+    payment_intent = stripe_manager.create_payment_intent(
+        organization_id=invoice.organization_id,
+        amount_cents=max(0, int(round(invoice.total * 100))),
+        invoice_id=invoice.invoice_id,
+    )
+    aggregator.mark_invoice_status(invoice_id, "sent")
+
+    return {
+        "status": "sent",
+        "invoice_id": invoice.invoice_id,
+        "payment_intent": payment_intent,
+    }
+
+
+@router.get("/admin/billing/forecast")
+async def forecast_spend(organization_id: str = Query(...)) -> Dict[str, Any]:
+    """Forecast monthly spend from trailing 7-day daily average."""
+    usage_meter = _get_usage_meter()
+    window_calls, daily_average_calls = await usage_meter.get_org_daily_average_calls(
+        organization_id=organization_id,
+        days=7,
+    )
+
+    projected_monthly_calls = daily_average_calls * 30
+    projected_monthly_spend = projected_monthly_calls * COST_PER_CALL_USD
+
+    return {
+        "organization_id": organization_id,
+        "window_days": 7,
+        "window_calls": window_calls,
+        "daily_average_calls": round(daily_average_calls, 4),
+        "projected_monthly_calls": round(projected_monthly_calls, 4),
+        "projected_monthly_spend": round(projected_monthly_spend, 6),
+        "generated_at": datetime.now(tz=UTC).isoformat(),
+    }

--- a/packages/api/services/billing_aggregation.py
+++ b/packages/api/services/billing_aggregation.py
@@ -1,0 +1,136 @@
+"""Monthly billing aggregation and invoice generation."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Dict, List, Optional, Tuple
+
+from services.usage_metering import COST_PER_CALL_USD, UsageMeterEngine, get_usage_meter_engine
+
+TAX_RATE = 0.085
+
+
+@dataclass
+class BillingLineItem:
+    """One invoice line item grouped by service."""
+
+    service: str
+    call_count: int
+    unit_cost: float
+    total_cost: float
+
+
+@dataclass
+class MonthlyInvoice:
+    """Monthly invoice aggregate for one organization."""
+
+    invoice_id: str
+    organization_id: str
+    month: str
+    line_items: List[BillingLineItem]
+    subtotal: float
+    tax: float
+    total: float
+    status: str
+    created_at: datetime
+    due_at: datetime
+
+
+class BillingAggregator:
+    """Generate and manage monthly invoices from metered usage."""
+
+    def __init__(self, usage_meter: Optional[UsageMeterEngine] = None) -> None:
+        self._usage_meter = usage_meter
+        self._invoices: Dict[str, MonthlyInvoice] = {}
+        self._invoice_index: Dict[Tuple[str, str], str] = {}
+
+    @property
+    def usage_meter(self) -> UsageMeterEngine:
+        """Get usage meter dependency."""
+        if self._usage_meter is None:
+            self._usage_meter = get_usage_meter_engine()
+        return self._usage_meter
+
+    async def generate_invoice(self, organization_id: str, month: str) -> MonthlyInvoice:
+        """Generate or return a monthly draft invoice for an organization."""
+        key = (organization_id, month)
+        existing_id = self._invoice_index.get(key)
+        if existing_id is not None:
+            return self._invoices[existing_id]
+
+        usage = await self.usage_meter.get_org_monthly_usage(organization_id, month)
+
+        line_items = [
+            BillingLineItem(
+                service=service,
+                call_count=service_usage.call_count,
+                unit_cost=COST_PER_CALL_USD,
+                total_cost=round(service_usage.call_count * COST_PER_CALL_USD, 6),
+            )
+            for service, service_usage in sorted(usage.by_service.items())
+        ]
+
+        subtotal = round(sum(line.total_cost for line in line_items), 6)
+        tax = round(subtotal * TAX_RATE, 6)
+        total = round(subtotal + tax, 6)
+        now = datetime.now(tz=UTC)
+
+        invoice = MonthlyInvoice(
+            invoice_id=str(uuid.uuid4()),
+            organization_id=organization_id,
+            month=month,
+            line_items=line_items,
+            subtotal=subtotal,
+            tax=tax,
+            total=total,
+            status="draft",
+            created_at=now,
+            due_at=now + timedelta(days=30),
+        )
+
+        self._invoices[invoice.invoice_id] = invoice
+        self._invoice_index[key] = invoice.invoice_id
+        return invoice
+
+    def list_invoices(self, organization_id: str) -> List[MonthlyInvoice]:
+        """List invoices for one organization, newest first."""
+        invoices = [
+            invoice
+            for invoice in self._invoices.values()
+            if invoice.organization_id == organization_id
+        ]
+        invoices.sort(key=lambda invoice: invoice.created_at, reverse=True)
+        return invoices
+
+    def get_invoice(self, invoice_id: str) -> Optional[MonthlyInvoice]:
+        """Get invoice by ID."""
+        return self._invoices.get(invoice_id)
+
+    def mark_invoice_status(self, invoice_id: str, status: str) -> Optional[MonthlyInvoice]:
+        """Update invoice status if present."""
+        invoice = self._invoices.get(invoice_id)
+        if invoice is None:
+            return None
+        invoice.status = status
+        return invoice
+
+
+_billing_aggregator: Optional[BillingAggregator] = None
+
+
+def get_billing_aggregator(
+    usage_meter: Optional[UsageMeterEngine] = None,
+) -> BillingAggregator:
+    """Return (or create) the global :class:`BillingAggregator`."""
+    global _billing_aggregator
+    if _billing_aggregator is None:
+        _billing_aggregator = BillingAggregator(usage_meter)
+    return _billing_aggregator
+
+
+def reset_billing_aggregator() -> None:
+    """Reset billing aggregator singleton (for tests)."""
+    global _billing_aggregator
+    _billing_aggregator = None

--- a/packages/api/services/free_tier_quota.py
+++ b/packages/api/services/free_tier_quota.py
@@ -1,0 +1,89 @@
+"""Free-tier monthly quota enforcement."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Optional, Tuple
+
+from schemas.agent_identity import AgentIdentityStore, get_agent_identity_store
+from services.usage_metering import UsageMeterEngine, get_usage_meter_engine
+
+FREE_TIER_LIMIT = 1000
+
+
+class FreeTierQuotaManager:
+    """Enforce free-tier monthly call quotas."""
+
+    def __init__(
+        self,
+        usage_meter: Optional[UsageMeterEngine] = None,
+        identity_store: Optional[AgentIdentityStore] = None,
+    ) -> None:
+        self._usage_meter = usage_meter
+        self._identity_store = identity_store
+
+    @property
+    def usage_meter(self) -> UsageMeterEngine:
+        """Get usage meter dependency."""
+        if self._usage_meter is None:
+            self._usage_meter = get_usage_meter_engine(identity_store=self.identity_store)
+        return self._usage_meter
+
+    @property
+    def identity_store(self) -> AgentIdentityStore:
+        """Get identity store dependency."""
+        if self._identity_store is None:
+            self._identity_store = get_agent_identity_store()
+        return self._identity_store
+
+    async def is_free_tier(self, agent_id: str) -> bool:
+        """Return True when agent has no Stripe customer mapping."""
+        agent = await self.identity_store.get_agent(agent_id)
+        if agent is None:
+            return True
+
+        custom_attributes = getattr(agent, "custom_attributes", {})
+        stripe_customer_id = None
+        if isinstance(custom_attributes, dict):
+            stripe_customer_id = custom_attributes.get("stripe_customer_id")
+
+        if not stripe_customer_id:
+            stripe_customer_id = getattr(agent, "stripe_customer_id", None)
+
+        return not bool(stripe_customer_id)
+
+    async def check_quota(self, agent_id: str) -> Tuple[bool, int]:
+        """Check if an agent can make another free-tier call.
+
+        Returns:
+            ``(allowed, remaining)`` where paid agents bypass quota and return
+            ``(True, -1)``.
+        """
+        if not await self.is_free_tier(agent_id):
+            return True, -1
+
+        month = datetime.now(tz=UTC).strftime("%Y-%m")
+        usage = await self.usage_meter.get_monthly_usage(agent_id, month)
+        remaining = max(0, FREE_TIER_LIMIT - usage.total_calls)
+        allowed = remaining > 0
+        return allowed, remaining
+
+
+_free_tier_quota_manager: Optional[FreeTierQuotaManager] = None
+
+
+def get_free_tier_quota_manager(
+    usage_meter: Optional[UsageMeterEngine] = None,
+    identity_store: Optional[AgentIdentityStore] = None,
+) -> FreeTierQuotaManager:
+    """Return (or create) the global :class:`FreeTierQuotaManager`."""
+    global _free_tier_quota_manager
+    if _free_tier_quota_manager is None:
+        _free_tier_quota_manager = FreeTierQuotaManager(usage_meter, identity_store)
+    return _free_tier_quota_manager
+
+
+def reset_free_tier_quota_manager() -> None:
+    """Reset quota manager singleton (for tests)."""
+    global _free_tier_quota_manager
+    _free_tier_quota_manager = None

--- a/packages/api/services/spend_cap.py
+++ b/packages/api/services/spend_cap.py
@@ -1,0 +1,132 @@
+"""Per-agent monthly spend-cap enforcement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Optional, Tuple
+
+from schemas.agent_identity import AgentIdentityStore, get_agent_identity_store
+from services.usage_metering import UsageMeterEngine, get_usage_meter_engine
+
+DEFAULT_MONTHLY_SPEND_CAP_USD = 100.0
+
+
+@dataclass
+class SpendCapAlert:
+    """Alert emitted when an agent approaches or exceeds spend cap."""
+
+    agent_id: str
+    spend_current: float
+    spend_limit: float
+    percent_used: float
+    alert_type: str
+
+
+class SpendCapManager:
+    """Enforce per-agent monthly spend caps based on metered usage."""
+
+    def __init__(
+        self,
+        usage_meter: Optional[UsageMeterEngine] = None,
+        identity_store: Optional[AgentIdentityStore] = None,
+    ) -> None:
+        self._usage_meter = usage_meter
+        self._identity_store = identity_store
+
+    @property
+    def usage_meter(self) -> UsageMeterEngine:
+        """Get usage meter dependency."""
+        if self._usage_meter is None:
+            self._usage_meter = get_usage_meter_engine(identity_store=self.identity_store)
+        return self._usage_meter
+
+    @property
+    def identity_store(self) -> AgentIdentityStore:
+        """Get identity store dependency."""
+        if self._identity_store is None:
+            self._identity_store = get_agent_identity_store()
+        return self._identity_store
+
+    async def check_spend_cap(self, agent_id: str) -> Tuple[bool, Optional[SpendCapAlert]]:
+        """Check if an agent is allowed to continue spending this month.
+
+        Returns:
+            ``(allowed, alert)`` where alert is ``None`` under 80% usage,
+            ``warning`` at >=80%, and ``critical`` above 100%.
+        """
+        agent = await self.identity_store.get_agent(agent_id)
+        if agent is None:
+            return False, None
+
+        month = datetime.now(tz=UTC).strftime("%Y-%m")
+        usage = await self.usage_meter.get_monthly_usage(agent_id, month)
+
+        spend_limit = _resolve_spend_limit(agent)
+        spend_current = usage.cost_estimate
+        percent_used = (spend_current / spend_limit * 100.0) if spend_limit > 0 else 0.0
+
+        alert: Optional[SpendCapAlert] = None
+        if percent_used > 100.0:
+            alert = SpendCapAlert(
+                agent_id=agent_id,
+                spend_current=spend_current,
+                spend_limit=spend_limit,
+                percent_used=percent_used,
+                alert_type="critical",
+            )
+            return False, alert
+
+        if percent_used >= 80.0:
+            alert = SpendCapAlert(
+                agent_id=agent_id,
+                spend_current=spend_current,
+                spend_limit=spend_limit,
+                percent_used=percent_used,
+                alert_type="warning",
+            )
+
+        return True, alert
+
+
+def _resolve_spend_limit(agent: object) -> float:
+    """Resolve spend cap from agent metadata with sane defaults."""
+    default = DEFAULT_MONTHLY_SPEND_CAP_USD
+
+    custom_attributes = getattr(agent, "custom_attributes", {})
+    if isinstance(custom_attributes, dict):
+        value = custom_attributes.get("monthly_spend_cap_usd")
+        if value is not None:
+            try:
+                return max(0.0, float(value))
+            except (TypeError, ValueError):
+                return default
+
+    explicit = getattr(agent, "monthly_spend_cap_usd", None)
+    if explicit is not None:
+        try:
+            return max(0.0, float(explicit))
+        except (TypeError, ValueError):
+            return default
+
+    return default
+
+
+_spend_cap_manager: Optional[SpendCapManager] = None
+
+
+def get_spend_cap_manager(
+    usage_meter: Optional[UsageMeterEngine] = None,
+    identity_store: Optional[AgentIdentityStore] = None,
+) -> SpendCapManager:
+    """Return (or create) the global :class:`SpendCapManager`."""
+    global _spend_cap_manager
+    if _spend_cap_manager is None:
+        _spend_cap_manager = SpendCapManager(usage_meter, identity_store)
+    return _spend_cap_manager
+
+
+def reset_spend_cap_manager() -> None:
+    """Reset spend cap singleton (for tests)."""
+    global _spend_cap_manager
+    _spend_cap_manager = None

--- a/packages/api/services/stripe_integration.py
+++ b/packages/api/services/stripe_integration.py
@@ -1,0 +1,127 @@
+"""Mock Stripe integration for billing flows.
+
+This module intentionally avoids the real Stripe SDK and provides a
+fully in-memory mock client suitable for deterministic tests.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Dict, Optional
+
+
+@dataclass
+class MockPaymentIntent:
+    """In-memory representation of a payment intent."""
+
+    payment_intent_id: str
+    organization_id: str
+    amount_cents: int
+    invoice_id: str
+    client_secret: str
+    status: str
+    created_at: datetime
+
+
+class MockStripeClient:
+    """Small in-memory mock Stripe client used by tests."""
+
+    def __init__(self) -> None:
+        self.customers: Dict[str, str] = {}
+        self.payment_intents: Dict[str, MockPaymentIntent] = {}
+
+    def create_customer(self, organization_id: str, name: str, email: str) -> str:
+        """Create (or return existing) customer for organization."""
+        if organization_id in self.customers:
+            return self.customers[organization_id]
+
+        customer_id = f"cus_{uuid.uuid4().hex[:16]}"
+        self.customers[organization_id] = customer_id
+        return customer_id
+
+    def create_payment_intent(
+        self,
+        organization_id: str,
+        amount_cents: int,
+        invoice_id: str,
+    ) -> Dict[str, str]:
+        """Create a mock payment intent and return public fields."""
+        payment_intent_id = f"pi_{uuid.uuid4().hex[:16]}"
+        client_secret = f"{payment_intent_id}_secret_{uuid.uuid4().hex[:24]}"
+        self.payment_intents[payment_intent_id] = MockPaymentIntent(
+            payment_intent_id=payment_intent_id,
+            organization_id=organization_id,
+            amount_cents=amount_cents,
+            invoice_id=invoice_id,
+            client_secret=client_secret,
+            status="requires_confirmation",
+            created_at=datetime.now(tz=UTC),
+        )
+        return {
+            "client_secret": client_secret,
+            "payment_intent_id": payment_intent_id,
+        }
+
+    def confirm_payment(self, payment_intent_id: str) -> bool:
+        """Confirm a payment intent if it exists."""
+        intent = self.payment_intents.get(payment_intent_id)
+        if intent is None:
+            return False
+
+        intent.status = "succeeded"
+        return True
+
+
+class StripeIntegrationManager:
+    """Facade for customer creation and payment-intent lifecycle."""
+
+    def __init__(self, stripe_client: Optional[MockStripeClient] = None) -> None:
+        self.client = stripe_client or MockStripeClient()
+        self._customer_by_org: Dict[str, str] = {}
+
+    def create_or_get_customer(self, organization_id: str, name: str, email: str) -> str:
+        """Create or fetch a Stripe customer mapping for organization."""
+        if organization_id in self._customer_by_org:
+            return self._customer_by_org[organization_id]
+
+        customer_id = self.client.create_customer(organization_id, name, email)
+        self._customer_by_org[organization_id] = customer_id
+        return customer_id
+
+    def create_payment_intent(
+        self,
+        organization_id: str,
+        amount_cents: int,
+        invoice_id: str,
+    ) -> Dict[str, str]:
+        """Create a payment intent for a monthly invoice."""
+        return self.client.create_payment_intent(
+            organization_id=organization_id,
+            amount_cents=amount_cents,
+            invoice_id=invoice_id,
+        )
+
+    def confirm_payment(self, payment_intent_id: str) -> bool:
+        """Confirm a payment intent."""
+        return self.client.confirm_payment(payment_intent_id)
+
+
+_stripe_manager: Optional[StripeIntegrationManager] = None
+
+
+def get_stripe_integration_manager(
+    stripe_client: Optional[MockStripeClient] = None,
+) -> StripeIntegrationManager:
+    """Return (or create) the global :class:`StripeIntegrationManager`."""
+    global _stripe_manager
+    if _stripe_manager is None:
+        _stripe_manager = StripeIntegrationManager(stripe_client)
+    return _stripe_manager
+
+
+def reset_stripe_integration_manager() -> None:
+    """Reset stripe manager singleton (for tests)."""
+    global _stripe_manager
+    _stripe_manager = None

--- a/packages/api/services/usage_metering.py
+++ b/packages/api/services/usage_metering.py
@@ -1,0 +1,338 @@
+"""Billing-oriented usage metering built on top of Round 11 analytics.
+
+Tracks metered proxy calls and exposes billing-friendly snapshots and
+monthly aggregates per agent and organization.
+"""
+
+from __future__ import annotations
+
+import math
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from schemas.agent_identity import AgentIdentityStore, get_agent_identity_store
+from services.agent_usage_analytics import AgentUsageAnalytics, get_usage_analytics
+
+COST_PER_CALL_USD = 0.001
+
+
+@dataclass
+class MeteredUsageEvent:
+    """Single metered proxy call event."""
+
+    event_id: str
+    agent_id: str
+    service: str
+    result: str
+    latency_ms: float
+    response_size_bytes: int
+    created_at: datetime
+
+
+@dataclass
+class UsageMeterSnapshot:
+    """Usage and latency snapshot for an agent/service over a period."""
+
+    agent_id: str
+    service: str
+    period_days: int
+    call_count: int
+    success_count: int
+    failed_count: int
+    rate_limited_count: int
+    p50_latency_ms: float
+    p95_latency_ms: float
+    p99_latency_ms: float
+    avg_response_size_bytes: float
+
+
+@dataclass
+class ServiceMonthlyUsage:
+    """Per-service monthly usage and cost for an agent or organization."""
+
+    call_count: int
+    cost_estimate: float
+
+
+@dataclass
+class MonthlyUsageSummary:
+    """Monthly usage summary for one agent."""
+
+    agent_id: str
+    month: str
+    total_calls: int
+    by_service: Dict[str, ServiceMonthlyUsage]
+    cost_estimate: float
+
+
+@dataclass
+class OrgMonthlyUsage:
+    """Monthly usage summary for one organization."""
+
+    organization_id: str
+    month: str
+    total_calls: int
+    by_service: Dict[str, ServiceMonthlyUsage]
+    by_agent: Dict[str, MonthlyUsageSummary]
+    cost_estimate: float
+
+
+class UsageMeterEngine:
+    """Metering engine that wraps :class:`AgentUsageAnalytics`.
+
+    Uses in-memory storage in v1; production persistence can be routed
+    to Supabase in later rounds.
+    """
+
+    def __init__(
+        self,
+        usage_analytics: Optional[AgentUsageAnalytics] = None,
+        identity_store: Optional[AgentIdentityStore] = None,
+        supabase_client: Any = None,
+    ) -> None:
+        self._analytics = usage_analytics
+        self._identity_store = identity_store
+        self.supabase = supabase_client
+        self._events: List[MeteredUsageEvent] = []
+
+    @property
+    def analytics(self) -> AgentUsageAnalytics:
+        """Get usage analytics dependency."""
+        if self._analytics is None:
+            self._analytics = get_usage_analytics(self.identity_store, self.supabase)
+        return self._analytics
+
+    @property
+    def identity_store(self) -> AgentIdentityStore:
+        """Get identity store dependency."""
+        if self._identity_store is None:
+            self._identity_store = get_agent_identity_store()
+        return self._identity_store
+
+    async def record_metered_call(
+        self,
+        agent_id: str,
+        service: str,
+        success: bool,
+        latency_ms: float,
+        response_size_bytes: int,
+    ) -> str:
+        """Record a metered proxy call.
+
+        Also records into Round 11 analytics to preserve a single source
+        of truth for general usage telemetry.
+
+        Returns:
+            Metered event ID.
+        """
+        result = "success" if success else "error"
+        await self.analytics.record_event(
+            agent_id=agent_id,
+            service=service,
+            result=result,
+            latency_ms=latency_ms,
+        )
+
+        event = MeteredUsageEvent(
+            event_id=str(uuid.uuid4()),
+            agent_id=agent_id,
+            service=service,
+            result=result,
+            latency_ms=latency_ms,
+            response_size_bytes=max(0, int(response_size_bytes)),
+            created_at=datetime.now(tz=UTC),
+        )
+
+        if self.supabase is not None:
+            self.supabase.table("agent_usage_events").insert(
+                {
+                    "event_id": event.event_id,
+                    "agent_id": event.agent_id,
+                    "service": event.service,
+                    "result": event.result,
+                    "latency_ms": event.latency_ms,
+                    "response_size_bytes": event.response_size_bytes,
+                    "created_at": event.created_at.isoformat(),
+                }
+            ).execute()
+        else:
+            self._events.append(event)
+
+        return event.event_id
+
+    async def get_usage_snapshot(
+        self,
+        agent_id: str,
+        service: str,
+        period_days: int,
+    ) -> Optional[UsageMeterSnapshot]:
+        """Get a usage snapshot for one agent/service over ``period_days``."""
+        cutoff = datetime.now(tz=UTC).timestamp() - (period_days * 86400)
+        events = [
+            event
+            for event in self._events
+            if event.agent_id == agent_id
+            and event.service == service
+            and event.created_at.timestamp() >= cutoff
+        ]
+
+        if not events:
+            return None
+
+        latencies = [event.latency_ms for event in events]
+        response_sizes = [event.response_size_bytes for event in events]
+
+        success_count = sum(1 for event in events if event.result == "success")
+        rate_limited_count = sum(1 for event in events if event.result == "rate_limited")
+        failed_count = sum(
+            1 for event in events if event.result in ("error", "auth_failed")
+        )
+
+        return UsageMeterSnapshot(
+            agent_id=agent_id,
+            service=service,
+            period_days=period_days,
+            call_count=len(events),
+            success_count=success_count,
+            failed_count=failed_count,
+            rate_limited_count=rate_limited_count,
+            p50_latency_ms=self._percentile(latencies, 50),
+            p95_latency_ms=self._percentile(latencies, 95),
+            p99_latency_ms=self._percentile(latencies, 99),
+            avg_response_size_bytes=(sum(response_sizes) / len(response_sizes)),
+        )
+
+    async def get_monthly_usage(self, agent_id: str, month: str) -> MonthlyUsageSummary:
+        """Get monthly usage summary for one agent.
+
+        Args:
+            agent_id: Agent identifier.
+            month: Month key in ``YYYY-MM`` format.
+        """
+        month_start, month_end = _month_bounds(month)
+        month_events = [
+            event
+            for event in self._events
+            if event.agent_id == agent_id and month_start <= event.created_at < month_end
+        ]
+
+        by_service_counts: Dict[str, int] = defaultdict(int)
+        for event in month_events:
+            by_service_counts[event.service] += 1
+
+        by_service: Dict[str, ServiceMonthlyUsage] = {
+            service: ServiceMonthlyUsage(
+                call_count=count,
+                cost_estimate=round(count * COST_PER_CALL_USD, 6),
+            )
+            for service, count in by_service_counts.items()
+        }
+
+        total_calls = len(month_events)
+        return MonthlyUsageSummary(
+            agent_id=agent_id,
+            month=month,
+            total_calls=total_calls,
+            by_service=by_service,
+            cost_estimate=round(total_calls * COST_PER_CALL_USD, 6),
+        )
+
+    async def get_org_monthly_usage(self, organization_id: str, month: str) -> OrgMonthlyUsage:
+        """Aggregate monthly usage across all agents in an organization."""
+        agents = await self.identity_store.list_agents(organization_id=organization_id)
+
+        by_agent: Dict[str, MonthlyUsageSummary] = {}
+        by_service_counts: Dict[str, int] = defaultdict(int)
+        total_calls = 0
+
+        for agent in agents:
+            summary = await self.get_monthly_usage(agent.agent_id, month)
+            by_agent[agent.agent_id] = summary
+            total_calls += summary.total_calls
+
+            for service, service_summary in summary.by_service.items():
+                by_service_counts[service] += service_summary.call_count
+
+        by_service: Dict[str, ServiceMonthlyUsage] = {
+            service: ServiceMonthlyUsage(
+                call_count=count,
+                cost_estimate=round(count * COST_PER_CALL_USD, 6),
+            )
+            for service, count in by_service_counts.items()
+        }
+
+        return OrgMonthlyUsage(
+            organization_id=organization_id,
+            month=month,
+            total_calls=total_calls,
+            by_service=by_service,
+            by_agent=by_agent,
+            cost_estimate=round(total_calls * COST_PER_CALL_USD, 6),
+        )
+
+    async def get_org_daily_average_calls(
+        self,
+        organization_id: str,
+        days: int = 7,
+    ) -> Tuple[int, float]:
+        """Return ``(window_calls, daily_average_calls)`` for an organization."""
+        cutoff = datetime.now(tz=UTC).timestamp() - (days * 86400)
+        agents = await self.identity_store.list_agents(organization_id=organization_id)
+        agent_ids = {agent.agent_id for agent in agents}
+
+        window_calls = sum(
+            1
+            for event in self._events
+            if event.agent_id in agent_ids and event.created_at.timestamp() >= cutoff
+        )
+        return window_calls, (window_calls / days if days > 0 else 0.0)
+
+    @staticmethod
+    def _percentile(values: List[float], percentile: int) -> float:
+        """Nearest-rank percentile for a list of values."""
+        if not values:
+            return 0.0
+
+        ordered = sorted(values)
+        if len(ordered) == 1:
+            return float(ordered[0])
+
+        rank = int(math.ceil((percentile / 100.0) * len(ordered))) - 1
+        rank = max(0, min(rank, len(ordered) - 1))
+        return float(ordered[rank])
+
+
+def _month_bounds(month: str) -> Tuple[datetime, datetime]:
+    """Return UTC datetime bounds ``[start, end)`` for ``YYYY-MM``."""
+    start = datetime.strptime(month, "%Y-%m").replace(tzinfo=UTC)
+
+    if start.month == 12:
+        end = start.replace(year=start.year + 1, month=1)
+    else:
+        end = start.replace(month=start.month + 1)
+
+    return start, end
+
+
+_meter_engine: Optional[UsageMeterEngine] = None
+
+
+def get_usage_meter_engine(
+    usage_analytics: Optional[AgentUsageAnalytics] = None,
+    identity_store: Optional[AgentIdentityStore] = None,
+    supabase_client: Any = None,
+) -> UsageMeterEngine:
+    """Return (or create) the global :class:`UsageMeterEngine`."""
+    global _meter_engine
+    if _meter_engine is None:
+        _meter_engine = UsageMeterEngine(usage_analytics, identity_store, supabase_client)
+    return _meter_engine
+
+
+def reset_usage_meter_engine() -> None:
+    """Reset usage meter singleton (for tests)."""
+    global _meter_engine
+    _meter_engine = None

--- a/packages/api/tests/test_billing.py
+++ b/packages/api/tests/test_billing.py
@@ -1,0 +1,656 @@
+"""Round 12 billing and metering tests (WU 2.3)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import create_app
+from routes.admin_billing import set_test_billing_stores
+from schemas.agent_identity import AgentIdentityStore, reset_identity_store
+from services.agent_usage_analytics import AgentUsageAnalytics, reset_usage_analytics
+from services.billing_aggregation import BillingAggregator, TAX_RATE, reset_billing_aggregator
+from services.free_tier_quota import (
+    FREE_TIER_LIMIT,
+    FreeTierQuotaManager,
+    reset_free_tier_quota_manager,
+)
+from services.spend_cap import (
+    DEFAULT_MONTHLY_SPEND_CAP_USD,
+    SpendCapManager,
+    reset_spend_cap_manager,
+)
+from services.stripe_integration import (
+    MockStripeClient,
+    StripeIntegrationManager,
+    reset_stripe_integration_manager,
+)
+from services.usage_metering import (
+    COST_PER_CALL_USD,
+    MeteredUsageEvent,
+    UsageMeterEngine,
+    reset_usage_meter_engine,
+)
+
+
+def _run(coro):  # type: ignore[no-untyped-def]
+    """Run async test helper in a dedicated event loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _seed_meter_events(
+    usage_meter: UsageMeterEngine,
+    agent_id: str,
+    service: str,
+    count: int,
+    result: str = "success",
+    latency_ms: float = 100.0,
+    response_size_bytes: int = 500,
+) -> None:
+    """Seed in-memory meter events without async overhead."""
+    now = datetime.now(tz=UTC)
+    for _ in range(count):
+        usage_meter._events.append(  # noqa: SLF001
+            MeteredUsageEvent(
+                event_id=str(uuid.uuid4()),
+                agent_id=agent_id,
+                service=service,
+                result=result,
+                latency_ms=latency_ms,
+                response_size_bytes=response_size_bytes,
+                created_at=now,
+            )
+        )
+
+
+def _set_custom_attrs(
+    identity_store: AgentIdentityStore,
+    agent_id: str,
+    attrs: dict[str, object],
+) -> None:
+    """Set custom attributes directly in in-memory identity store."""
+    identity_store._mem_agents[agent_id]["custom_attributes"] = json.dumps(attrs)  # noqa: SLF001
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons() -> Generator[None, None, None]:
+    """Reset singletons and route test stores between tests."""
+    reset_identity_store()
+    reset_usage_analytics()
+    reset_usage_meter_engine()
+    reset_spend_cap_manager()
+    reset_free_tier_quota_manager()
+    reset_billing_aggregator()
+    reset_stripe_integration_manager()
+    set_test_billing_stores(None, None, None)
+    yield
+    reset_identity_store()
+    reset_usage_analytics()
+    reset_usage_meter_engine()
+    reset_spend_cap_manager()
+    reset_free_tier_quota_manager()
+    reset_billing_aggregator()
+    reset_stripe_integration_manager()
+    set_test_billing_stores(None, None, None)
+
+
+@pytest.fixture
+def identity_store() -> AgentIdentityStore:
+    """In-memory identity store."""
+    return AgentIdentityStore(supabase_client=None)
+
+
+@pytest.fixture
+def usage_analytics(identity_store: AgentIdentityStore) -> AgentUsageAnalytics:
+    """In-memory usage analytics."""
+    return AgentUsageAnalytics(identity_store=identity_store)
+
+
+@pytest.fixture
+def usage_meter(
+    identity_store: AgentIdentityStore,
+    usage_analytics: AgentUsageAnalytics,
+) -> UsageMeterEngine:
+    """In-memory usage meter engine."""
+    return UsageMeterEngine(usage_analytics=usage_analytics, identity_store=identity_store)
+
+
+@pytest.fixture
+def spend_cap_manager(
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> SpendCapManager:
+    """Spend cap manager fixture."""
+    return SpendCapManager(usage_meter=usage_meter, identity_store=identity_store)
+
+
+@pytest.fixture
+def free_tier_manager(
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> FreeTierQuotaManager:
+    """Free tier quota manager fixture."""
+    return FreeTierQuotaManager(usage_meter=usage_meter, identity_store=identity_store)
+
+
+@pytest.fixture
+def billing_aggregator(usage_meter: UsageMeterEngine) -> BillingAggregator:
+    """Billing aggregator fixture."""
+    return BillingAggregator(usage_meter=usage_meter)
+
+
+@pytest.fixture
+def stripe_manager() -> StripeIntegrationManager:
+    """Stripe integration fixture with mock client."""
+    return StripeIntegrationManager(stripe_client=MockStripeClient())
+
+
+@pytest.fixture
+def admin_client(
+    usage_meter: UsageMeterEngine,
+    billing_aggregator: BillingAggregator,
+    stripe_manager: StripeIntegrationManager,
+) -> TestClient:
+    """FastAPI client wired with billing test stores."""
+    set_test_billing_stores(usage_meter, billing_aggregator, stripe_manager)
+    app = create_app()
+    return TestClient(app)
+
+
+def _register_agent(identity_store: AgentIdentityStore, organization_id: str = "org_1") -> str:
+    """Register a test agent and return its agent_id."""
+    agent_id, _ = _run(
+        identity_store.register_agent(
+            name="billing-agent",
+            organization_id=organization_id,
+        )
+    )
+    return agent_id
+
+
+# ── Usage metering tests ─────────────────────────────────────────────
+
+
+def test_record_metered_call_success(usage_meter: UsageMeterEngine, identity_store: AgentIdentityStore) -> None:
+    agent_id = _register_agent(identity_store)
+    _run(usage_meter.record_metered_call(agent_id, "openai", True, 120.0, 1024))
+
+    summary = _run(usage_meter.get_monthly_usage(agent_id, datetime.now(tz=UTC).strftime("%Y-%m")))
+    assert summary.total_calls == 1
+    assert summary.cost_estimate == pytest.approx(0.001)
+
+
+def test_record_metered_call_failure(usage_meter: UsageMeterEngine, identity_store: AgentIdentityStore) -> None:
+    agent_id = _register_agent(identity_store)
+    _run(usage_meter.record_metered_call(agent_id, "openai", False, 200.0, 512))
+
+    snapshot = _run(usage_meter.get_usage_snapshot(agent_id, "openai", 7))
+    assert snapshot is not None
+    assert snapshot.failed_count == 1
+    assert snapshot.success_count == 0
+
+
+def test_usage_snapshot_single_service(
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store)
+    _seed_meter_events(usage_meter, agent_id, "anthropic", 3, result="success", latency_ms=150.0)
+    _seed_meter_events(usage_meter, agent_id, "anthropic", 1, result="error", latency_ms=350.0)
+    _seed_meter_events(usage_meter, agent_id, "anthropic", 1, result="rate_limited", latency_ms=50.0)
+
+    snapshot = _run(usage_meter.get_usage_snapshot(agent_id, "anthropic", 30))
+    assert snapshot is not None
+    assert snapshot.call_count == 5
+    assert snapshot.success_count == 3
+    assert snapshot.failed_count == 1
+    assert snapshot.rate_limited_count == 1
+    assert snapshot.avg_response_size_bytes == pytest.approx(500.0)
+
+
+def test_usage_snapshot_empty_returns_none(
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store)
+    snapshot = _run(usage_meter.get_usage_snapshot(agent_id, "openai", 7))
+    assert snapshot is None
+
+
+def test_monthly_usage_single_agent(
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store)
+    _seed_meter_events(usage_meter, agent_id, "openai", 10)
+
+    summary = _run(usage_meter.get_monthly_usage(agent_id, datetime.now(tz=UTC).strftime("%Y-%m")))
+    assert summary.total_calls == 10
+    assert summary.by_service["openai"].call_count == 10
+    assert summary.cost_estimate == pytest.approx(0.01)
+
+
+def test_monthly_usage_multiple_services(
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store)
+    _seed_meter_events(usage_meter, agent_id, "openai", 3)
+    _seed_meter_events(usage_meter, agent_id, "anthropic", 2)
+
+    summary = _run(usage_meter.get_monthly_usage(agent_id, datetime.now(tz=UTC).strftime("%Y-%m")))
+    assert summary.total_calls == 5
+    assert summary.by_service["openai"].call_count == 3
+    assert summary.by_service["anthropic"].call_count == 2
+
+
+def test_org_monthly_usage_aggregation(
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_a = _register_agent(identity_store, "org_x")
+    agent_b = _register_agent(identity_store, "org_x")
+    _seed_meter_events(usage_meter, agent_a, "openai", 4)
+    _seed_meter_events(usage_meter, agent_b, "openai", 6)
+
+    org_summary = _run(
+        usage_meter.get_org_monthly_usage("org_x", datetime.now(tz=UTC).strftime("%Y-%m"))
+    )
+    assert org_summary.total_calls == 10
+    assert org_summary.by_service["openai"].call_count == 10
+    assert len(org_summary.by_agent) == 2
+
+
+def test_percentile_calculation(
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store)
+    latencies = [100.0, 200.0, 300.0, 400.0, 500.0]
+    for latency in latencies:
+        _seed_meter_events(usage_meter, agent_id, "openai", 1, latency_ms=latency)
+
+    snapshot = _run(usage_meter.get_usage_snapshot(agent_id, "openai", 7))
+    assert snapshot is not None
+    assert snapshot.p50_latency_ms == 300.0
+    assert snapshot.p95_latency_ms == 500.0
+    assert snapshot.p99_latency_ms == 500.0
+
+
+# ── Spend cap tests ──────────────────────────────────────────────────
+
+
+def test_spend_within_limit_no_alert(
+    spend_cap_manager: SpendCapManager,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store)
+    _set_custom_attrs(identity_store, agent_id, {"monthly_spend_cap_usd": 1.0})
+    _seed_meter_events(usage_meter, agent_id, "openai", 100)
+
+    allowed, alert = _run(spend_cap_manager.check_spend_cap(agent_id))
+    assert allowed is True
+    assert alert is None
+
+
+def test_spend_at_80_percent_warning(
+    spend_cap_manager: SpendCapManager,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store)
+    _set_custom_attrs(identity_store, agent_id, {"monthly_spend_cap_usd": 0.01})
+    _seed_meter_events(usage_meter, agent_id, "openai", 8)
+
+    allowed, alert = _run(spend_cap_manager.check_spend_cap(agent_id))
+    assert allowed is True
+    assert alert is not None
+    assert alert.alert_type == "warning"
+    assert alert.percent_used == pytest.approx(80.0)
+
+
+def test_spend_exceeds_limit_blocked(
+    spend_cap_manager: SpendCapManager,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store)
+    _set_custom_attrs(identity_store, agent_id, {"monthly_spend_cap_usd": 0.002})
+    _seed_meter_events(usage_meter, agent_id, "openai", 3)
+
+    allowed, alert = _run(spend_cap_manager.check_spend_cap(agent_id))
+    assert allowed is False
+    assert alert is not None
+    assert alert.alert_type == "critical"
+
+
+def test_default_spend_cap_100(
+    spend_cap_manager: SpendCapManager,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store)
+    allowed, alert = _run(spend_cap_manager.check_spend_cap(agent_id))
+
+    assert allowed is True
+    assert alert is None
+
+    # Verify default constant is used by implementation contract.
+    assert DEFAULT_MONTHLY_SPEND_CAP_USD == 100.0
+
+
+def test_custom_spend_cap(
+    spend_cap_manager: SpendCapManager,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store)
+    _set_custom_attrs(identity_store, agent_id, {"monthly_spend_cap_usd": 2.0})
+    _seed_meter_events(usage_meter, agent_id, "openai", 1500)
+
+    allowed, alert = _run(spend_cap_manager.check_spend_cap(agent_id))
+    assert allowed is True
+    assert alert is None
+
+
+# ── Free tier tests ──────────────────────────────────────────────────
+
+
+def test_free_tier_active_no_stripe(
+    free_tier_manager: FreeTierQuotaManager,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store)
+    assert _run(free_tier_manager.is_free_tier(agent_id)) is True
+
+
+def test_free_tier_quota_within_limit(
+    free_tier_manager: FreeTierQuotaManager,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store)
+    _seed_meter_events(usage_meter, agent_id, "openai", 10)
+
+    allowed, remaining = _run(free_tier_manager.check_quota(agent_id))
+    assert allowed is True
+    assert remaining == FREE_TIER_LIMIT - 10
+
+
+def test_free_tier_quota_exceeded(
+    free_tier_manager: FreeTierQuotaManager,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store)
+    _seed_meter_events(usage_meter, agent_id, "openai", FREE_TIER_LIMIT)
+
+    allowed, remaining = _run(free_tier_manager.check_quota(agent_id))
+    assert allowed is False
+    assert remaining == 0
+
+
+def test_paid_tier_bypasses_quota(
+    free_tier_manager: FreeTierQuotaManager,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store)
+    _set_custom_attrs(identity_store, agent_id, {"stripe_customer_id": "cus_test123"})
+    _seed_meter_events(usage_meter, agent_id, "openai", FREE_TIER_LIMIT + 500)
+
+    allowed, remaining = _run(free_tier_manager.check_quota(agent_id))
+    assert allowed is True
+    assert remaining == -1
+
+
+# ── Billing tests ────────────────────────────────────────────────────
+
+
+def test_generate_invoice_single_agent(
+    billing_aggregator: BillingAggregator,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store, "org_bill")
+    _seed_meter_events(usage_meter, agent_id, "openai", 10)
+
+    invoice = _run(
+        billing_aggregator.generate_invoice(
+            organization_id="org_bill",
+            month=datetime.now(tz=UTC).strftime("%Y-%m"),
+        )
+    )
+    assert invoice.organization_id == "org_bill"
+    assert invoice.subtotal == pytest.approx(0.01)
+
+
+def test_generate_invoice_multiple_agents(
+    billing_aggregator: BillingAggregator,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_a = _register_agent(identity_store, "org_multi")
+    agent_b = _register_agent(identity_store, "org_multi")
+    _seed_meter_events(usage_meter, agent_a, "openai", 5)
+    _seed_meter_events(usage_meter, agent_b, "openai", 7)
+
+    invoice = _run(
+        billing_aggregator.generate_invoice("org_multi", datetime.now(tz=UTC).strftime("%Y-%m"))
+    )
+    assert invoice.subtotal == pytest.approx(0.012)
+
+
+def test_invoice_line_items_by_service(
+    billing_aggregator: BillingAggregator,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store, "org_line")
+    _seed_meter_events(usage_meter, agent_id, "openai", 3)
+    _seed_meter_events(usage_meter, agent_id, "anthropic", 2)
+
+    invoice = _run(
+        billing_aggregator.generate_invoice("org_line", datetime.now(tz=UTC).strftime("%Y-%m"))
+    )
+    by_service = {line.service: line for line in invoice.line_items}
+    assert by_service["openai"].call_count == 3
+    assert by_service["anthropic"].call_count == 2
+
+
+def test_invoice_tax_calculation(
+    billing_aggregator: BillingAggregator,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store, "org_tax")
+    _seed_meter_events(usage_meter, agent_id, "openai", 100)
+
+    invoice = _run(
+        billing_aggregator.generate_invoice("org_tax", datetime.now(tz=UTC).strftime("%Y-%m"))
+    )
+    assert invoice.tax == pytest.approx(invoice.subtotal * TAX_RATE)
+    assert invoice.total == pytest.approx(invoice.subtotal + invoice.tax)
+
+
+def test_invoice_stored_as_draft(
+    billing_aggregator: BillingAggregator,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store, "org_draft")
+    _seed_meter_events(usage_meter, agent_id, "openai", 1)
+
+    invoice = _run(
+        billing_aggregator.generate_invoice("org_draft", datetime.now(tz=UTC).strftime("%Y-%m"))
+    )
+    listed = billing_aggregator.list_invoices("org_draft")
+    assert invoice.status == "draft"
+    assert len(listed) == 1
+    assert listed[0].invoice_id == invoice.invoice_id
+
+
+# ── Stripe tests (mock only) ────────────────────────────────────────
+
+
+def test_create_stripe_customer(stripe_manager: StripeIntegrationManager) -> None:
+    customer_id = stripe_manager.create_or_get_customer("org_1", "Acme", "ops@acme.ai")
+    assert customer_id.startswith("cus_")
+
+
+def test_get_existing_customer(stripe_manager: StripeIntegrationManager) -> None:
+    first = stripe_manager.create_or_get_customer("org_1", "Acme", "ops@acme.ai")
+    second = stripe_manager.create_or_get_customer("org_1", "Acme", "ops@acme.ai")
+    assert first == second
+
+
+def test_create_payment_intent(stripe_manager: StripeIntegrationManager) -> None:
+    intent = stripe_manager.create_payment_intent("org_1", 1234, "inv_1")
+    assert intent["payment_intent_id"].startswith("pi_")
+    assert "client_secret" in intent
+
+
+def test_confirm_payment_success(stripe_manager: StripeIntegrationManager) -> None:
+    intent = stripe_manager.create_payment_intent("org_1", 500, "inv_2")
+    ok = stripe_manager.confirm_payment(intent["payment_intent_id"])
+    assert ok is True
+
+
+def test_confirm_payment_failure(stripe_manager: StripeIntegrationManager) -> None:
+    ok = stripe_manager.confirm_payment("pi_missing")
+    assert ok is False
+
+
+# ── Admin route tests ────────────────────────────────────────────────
+
+
+def test_get_usage_report(
+    admin_client: TestClient,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store, "org_route_usage")
+    _seed_meter_events(usage_meter, agent_id, "openai", 9)
+
+    month = datetime.now(tz=UTC).strftime("%Y-%m")
+    response = admin_client.get(
+        "/v1/admin/billing/usage",
+        params={"organization_id": "org_route_usage", "month": month},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total_calls"] == 9
+
+
+def test_list_invoices_empty(admin_client: TestClient) -> None:
+    response = admin_client.get(
+        "/v1/admin/billing/invoices",
+        params={"organization_id": "org_empty"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_generate_invoice_endpoint(
+    admin_client: TestClient,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store, "org_generate")
+    _seed_meter_events(usage_meter, agent_id, "openai", 4)
+
+    month = datetime.now(tz=UTC).strftime("%Y-%m")
+    response = admin_client.post(
+        "/v1/admin/billing/invoices/generate",
+        json={"organization_id": "org_generate", "month": month},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "draft"
+    assert payload["subtotal"] == pytest.approx(4 * COST_PER_CALL_USD)
+
+
+def test_send_invoice_endpoint(
+    admin_client: TestClient,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store, "org_send")
+    _seed_meter_events(usage_meter, agent_id, "openai", 3)
+
+    month = datetime.now(tz=UTC).strftime("%Y-%m")
+    generate = admin_client.post(
+        "/v1/admin/billing/invoices/generate",
+        json={"organization_id": "org_send", "month": month},
+    )
+    invoice_id = generate.json()["invoice_id"]
+
+    send = admin_client.post(f"/v1/admin/billing/invoices/{invoice_id}/send")
+    assert send.status_code == 200
+    payload = send.json()
+    assert payload["status"] == "sent"
+    assert payload["payment_intent"]["payment_intent_id"].startswith("pi_")
+
+
+def test_forecast_spend(
+    admin_client: TestClient,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store, "org_forecast")
+    _seed_meter_events(usage_meter, agent_id, "openai", 14)
+
+    response = admin_client.get(
+        "/v1/admin/billing/forecast",
+        params={"organization_id": "org_forecast"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["window_calls"] == 14
+    assert payload["projected_monthly_spend"] == pytest.approx((14 / 7) * 30 * COST_PER_CALL_USD)
+
+
+# ── E2E integration tests ────────────────────────────────────────────
+
+
+def test_e2e_free_tier_to_paid_upgrade(
+    free_tier_manager: FreeTierQuotaManager,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store, "org_upgrade")
+    _seed_meter_events(usage_meter, agent_id, "openai", FREE_TIER_LIMIT)
+
+    allowed, remaining = _run(free_tier_manager.check_quota(agent_id))
+    assert allowed is False
+    assert remaining == 0
+
+    _set_custom_attrs(identity_store, agent_id, {"stripe_customer_id": "cus_upgraded"})
+    allowed_after, remaining_after = _run(free_tier_manager.check_quota(agent_id))
+    assert allowed_after is True
+    assert remaining_after == -1
+
+
+def test_e2e_spend_cap_blocks_at_limit(
+    spend_cap_manager: SpendCapManager,
+    usage_meter: UsageMeterEngine,
+    identity_store: AgentIdentityStore,
+) -> None:
+    agent_id = _register_agent(identity_store, "org_cap")
+    _set_custom_attrs(identity_store, agent_id, {"monthly_spend_cap_usd": 0.003})
+    _seed_meter_events(usage_meter, agent_id, "openai", 4)
+
+    allowed, alert = _run(spend_cap_manager.check_spend_cap(agent_id))
+    assert allowed is False
+    assert alert is not None
+    assert alert.alert_type == "critical"


### PR DESCRIPTION
## Summary
- add Round 12 metering service (`packages/api/services/usage_metering.py`) with snapshots, monthly agent/org aggregation, and cost estimation
- add spend-cap, free-tier quota, billing aggregation, and mocked Stripe integration services
- add admin billing routes for usage reports, invoice generation/list/send, and 7-day spend forecasting
- add Supabase migration DDL for metering + billing tables/columns/indexes
- add comprehensive billing test suite (`packages/api/tests/test_billing.py`) with 34 tests across usage, spend cap, quotas, invoices, Stripe, routes, and E2E paths
- register new admin billing router in `packages/api/app.py`

## Validation
- `cd packages/api && python3 -m pytest tests/test_billing.py -v` ✅ (34 passed)
- `cd packages/api && python3 -m pytest tests/ -v` ⚠️ existing unrelated baseline failures remain in `tests/test_leaderboard_search.py` and `tests/test_proxy_benchmarks.py` on `feat/r11-agent-identity-system` as well (verified via clean worktree)
