### PR TITLE
feat: Round 13 — Schema Change Detection (40+ tests, 5 modules)

### DIFF
--- a/packages/api/app.py
+++ b/packages/api/app.py
@@ -25,6 +25,7 @@ def create_app() -> FastAPI:
     application.include_router(leaderboard.router, prefix="/v1", tags=["leaderboard"])
     application.include_router(tester_fleet.router, prefix="/v1", tags=["tester-fleet"])
     application.include_router(proxy.router, prefix="/v1/proxy", tags=["proxy"])
+    application.include_router(proxy.admin_router, prefix="/v1", tags=["schema-admin"])
     application.include_router(
         admin_agents.router, prefix="/v1/admin", tags=["admin-agents"]
     )

--- a/packages/api/migrations/0007_schema_detection.sql
+++ b/packages/api/migrations/0007_schema_detection.sql
@@ -1,0 +1,48 @@
+-- Round 13 (WU 2.4): Schema change detection
+
+CREATE TABLE IF NOT EXISTS schema_fingerprints (
+    id BIGSERIAL PRIMARY KEY,
+    service_id BIGINT NOT NULL,
+    endpoint TEXT NOT NULL,
+    fingerprint_hash TEXT NOT NULL,
+    schema_tree JSONB,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE(service_id, endpoint)
+);
+
+CREATE TABLE IF NOT EXISTS schema_events (
+    id BIGSERIAL PRIMARY KEY,
+    service_id BIGINT NOT NULL,
+    endpoint TEXT NOT NULL,
+    fingerprint_hash TEXT NOT NULL,
+    change_type TEXT,
+    severity TEXT,
+    captured_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_schema_events_service FOREIGN KEY (service_id) REFERENCES services(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_schema_events_service_endpoint
+    ON schema_events(service_id, endpoint);
+CREATE INDEX IF NOT EXISTS idx_schema_events_captured_at
+    ON schema_events(captured_at DESC);
+
+CREATE TABLE IF NOT EXISTS schema_alerts (
+    id BIGSERIAL PRIMARY KEY,
+    service_id BIGINT NOT NULL,
+    endpoint TEXT NOT NULL,
+    change_detail JSONB,
+    severity TEXT,
+    alert_sent_at TIMESTAMP WITH TIME ZONE,
+    webhook_url TEXT,
+    webhook_status INT,
+    retry_count INT NOT NULL DEFAULT 0,
+    retry_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_schema_alerts_service FOREIGN KEY (service_id) REFERENCES services(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_schema_alerts_service_pending
+    ON schema_alerts(service_id)
+    WHERE webhook_status IS NULL;
+CREATE INDEX IF NOT EXISTS idx_schema_alerts_created_at
+    ON schema_alerts(created_at DESC);

--- a/packages/api/routes/leaderboard.py
+++ b/packages/api/routes/leaderboard.py
@@ -2,8 +2,11 @@
 
 import json
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
+
 from fastapi import APIRouter, Query
+
+from services.schema_change_detector import get_schema_change_detector
 
 router = APIRouter()
 
@@ -11,10 +14,23 @@ router = APIRouter()
 DATASET_SCORES_PATH = Path(__file__).parent.parent.parent / "web" / "public" / "data" / "initial-dataset.yaml"
 SCORES_PATH = Path(__file__).parent.parent / "artifacts" / "dataset-scores.json"
 
-_cached_scores = None
+_cached_scores: dict[str, Any] | None = None
 
 
-def _load_scores() -> dict:
+def _schema_freshness_multiplier(service_slug: str) -> tuple[float, float | None]:
+    """Return confidence multiplier based on schema stability window."""
+    detector = get_schema_change_detector()
+    stability_days = detector.get_service_stability_days(service_slug)
+    if stability_days is None:
+        return 1.0, None
+    if stability_days >= 30:
+        return 1.05, stability_days
+    if stability_days >= 14:
+        return 1.02, stability_days
+    return 1.0, stability_days
+
+
+def _load_scores() -> dict[str, Any]:
     """Load cached scores from artifact."""
     global _cached_scores
     if _cached_scores is not None:
@@ -32,14 +48,15 @@ def _load_scores() -> dict:
 def _get_service_categories() -> dict[str, list[str]]:
     """Load service categories from dataset YAML."""
     try:
-        import yaml
+        import yaml  # type: ignore[import-untyped]
+
         if not DATASET_SCORES_PATH.exists():
             return {}
 
         with open(DATASET_SCORES_PATH, "r") as f:
-            dataset = yaml.safe_load(f)
+            dataset: dict[str, Any] = yaml.safe_load(f) or {}
 
-        categories = {}
+        categories: dict[str, list[str]] = {}
         for service in dataset.get("services", []):
             slug = service.get("slug")
             category = service.get("category")
@@ -88,6 +105,13 @@ async def get_leaderboard(
         if score_item.get("service_slug") not in category_slugs:
             continue
 
+        multiplier, stability_days = _schema_freshness_multiplier(
+            str(score_item.get("service_slug"))
+        )
+        confidence = score_item.get("confidence")
+        if isinstance(confidence, (int, float)):
+            confidence = round(min(1.0, float(confidence) * multiplier), 4)
+
         items.append({
             "service_slug": score_item.get("service_slug"),
             "score": score_item.get("aggregate_recommendation_score"),
@@ -95,9 +119,11 @@ async def get_leaderboard(
             "access_score": score_item.get("access_readiness_score"),
             "tier": score_item.get("tier"),
             "tier_label": score_item.get("tier_label"),
-            "confidence": score_item.get("confidence"),
+            "confidence": confidence,
             "freshness": score_item.get("probe_metadata", {}).get("freshness"),
-            "calculated_at": score_item.get("calculated_at")
+            "schema_stability_days": round(stability_days, 3) if stability_days else None,
+            "freshness_multiplier": multiplier,
+            "calculated_at": score_item.get("calculated_at"),
         })
 
     # Sort by aggregate score descending

--- a/packages/api/routes/proxy.py
+++ b/packages/api/routes/proxy.py
@@ -1,20 +1,32 @@
 """Proxy route implementation for provisioning and agent-gated access.
 
 Slice B additions: connection pool manager, circuit breaker, latency tracking.
+Round 13 additions: schema fingerprinting, change detection, and alert pipeline.
 """
 
+from __future__ import annotations
+
 import time
+from datetime import UTC, datetime
 from typing import Any, Optional
 
 import httpx
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from services.proxy_breaker import BreakerRegistry, BreakerState
+from services.proxy_breaker import BreakerRegistry
 from services.proxy_latency import LatencyTracker
 from services.proxy_pool import PoolManager
+from services.schema_alert_pipeline import AlertDispatcher, get_alert_dispatcher
+from services.schema_change_detector import (
+    SchemaChange,
+    SchemaChangeDetector,
+    get_schema_change_detector,
+)
+from services.schema_fingerprint import SchemaFingerprint, fingerprint_response
 
 router = APIRouter(tags=["proxy"])
+admin_router = APIRouter(tags=["schema-admin"])
 
 # Service registry: maps service names to provider domains and auth patterns
 SERVICE_REGISTRY = {
@@ -22,26 +34,31 @@ SERVICE_REGISTRY = {
         "domain": "api.stripe.com",
         "auth_type": "bearer_token",
         "rate_limit": "100/min",
+        "schema_alert_mode": "breaking_only",
     },
     "slack": {
         "domain": "slack.com",
         "auth_type": "bearer_token",
         "rate_limit": "60/min",
+        "schema_alert_mode": "breaking_only",
     },
     "sendgrid": {
         "domain": "api.sendgrid.com",
         "auth_type": "bearer_token",
         "rate_limit": "300/min",
+        "schema_alert_mode": "breaking_only",
     },
     "github": {
         "domain": "api.github.com",
         "auth_type": "bearer_token",
         "rate_limit": "5000/hour",
+        "schema_alert_mode": "breaking_only",
     },
     "twilio": {
         "domain": "api.twilio.com",
         "auth_type": "basic_auth",
         "rate_limit": "1000/min",
+        "schema_alert_mode": "breaking_only",
     },
 }
 
@@ -77,6 +94,11 @@ class ProxyResponse(BaseModel):
 _pool_manager: Optional[PoolManager] = None
 _breaker_registry: Optional[BreakerRegistry] = None
 _latency_tracker: Optional[LatencyTracker] = None
+_schema_detector: Optional[SchemaChangeDetector] = None
+_schema_alert_dispatcher: Optional[AlertDispatcher] = None
+
+# Lightweight in-memory schema events storage.
+_schema_events: list[dict[str, Any]] = []
 
 # Legacy fallback client (used only if pool manager is not initialized)
 _http_client: Optional[httpx.AsyncClient] = None
@@ -106,6 +128,22 @@ def get_latency_tracker() -> LatencyTracker:
     return _latency_tracker
 
 
+def get_schema_detector() -> SchemaChangeDetector:
+    """Get or create the global schema change detector."""
+    global _schema_detector
+    if _schema_detector is None:
+        _schema_detector = get_schema_change_detector()
+    return _schema_detector
+
+
+def get_schema_alert_dispatcher() -> AlertDispatcher:
+    """Get or create the global schema alert dispatcher."""
+    global _schema_alert_dispatcher
+    if _schema_alert_dispatcher is None:
+        _schema_alert_dispatcher = get_alert_dispatcher()
+    return _schema_alert_dispatcher
+
+
 async def get_http_client() -> httpx.AsyncClient:
     """Get or create HTTP client (legacy fallback, prefer pool manager)."""
     global _http_client
@@ -122,7 +160,10 @@ def _get_service_config(service: str) -> dict:
     if service not in SERVICE_REGISTRY:
         raise HTTPException(
             status_code=400,
-            detail=f"Service '{service}' not found. Available: {', '.join(SERVICE_REGISTRY.keys())}",
+            detail=(
+                f"Service '{service}' not found. "
+                f"Available: {', '.join(SERVICE_REGISTRY.keys())}"
+            ),
         )
     return SERVICE_REGISTRY[service]
 
@@ -136,14 +177,91 @@ def _build_url(service: str, path: str) -> str:
     return f"https://{domain}{path}"
 
 
+def _schema_endpoint_key(agent_id: str, endpoint_path: str) -> str:
+    clean_path = endpoint_path.lstrip("/")
+    return f"{agent_id}:{clean_path}"
+
+
+def _append_schema_events(
+    *,
+    service: str,
+    endpoint: str,
+    fingerprint: SchemaFingerprint,
+    status_code: int,
+    changes: tuple[SchemaChange, ...],
+    warnings: tuple[str, ...],
+) -> None:
+    timestamp = datetime.now(tz=UTC).isoformat()
+
+    if not changes:
+        _schema_events.append(
+            {
+                "service": service,
+                "endpoint": endpoint,
+                "fingerprint_hash": fingerprint.fingerprint_hash,
+                "change_type": "none",
+                "severity": "advisory",
+                "captured_at": timestamp,
+                "status_code": status_code,
+                "warnings": list(warnings),
+            }
+        )
+        return
+
+    for change in changes:
+        _schema_events.append(
+            {
+                "service": service,
+                "endpoint": endpoint,
+                "fingerprint_hash": fingerprint.fingerprint_hash,
+                "change_type": change.change_type,
+                "severity": change.severity,
+                "path": change.path,
+                "old_type": change.old_type,
+                "new_type": change.new_type,
+                "detail": change.detail,
+                "similarity": change.similarity,
+                "captured_at": timestamp,
+                "status_code": status_code,
+                "warnings": list(warnings),
+            }
+        )
+
+
+async def _dispatch_schema_alert_task(
+    *,
+    service: str,
+    endpoint: str,
+    changes: tuple[SchemaChange, ...],
+    alert_mode: str,
+) -> None:
+    dispatcher = get_schema_alert_dispatcher()
+    await dispatcher.dispatch(
+        service=service,
+        endpoint=endpoint,
+        changes=changes,
+        alert_mode=alert_mode,
+    )
+
+
+def _max_severity(changes: tuple[SchemaChange, ...]) -> str:
+    severities = {change.severity for change in changes}
+    if "breaking" in severities:
+        return "breaking"
+    if "non_breaking" in severities:
+        return "non_breaking"
+    return "advisory"
+
+
 @router.post("/", response_model=ProxyResponse)
 async def proxy_request(
     request: ProxyRequest,
+    background_tasks: BackgroundTasks,
     authorization: Optional[str] = Header(None),
 ) -> ProxyResponse:
     """Proxy a request to a provider API.
 
-    Integrates connection pooling, circuit breaker, and latency tracking.
+    Integrates connection pooling, circuit breaker, latency tracking.
 
     The proxy:
     - Checks circuit breaker state (fail-open if OPEN)
@@ -151,11 +269,11 @@ async def proxy_request(
     - Forwards the request with auth headers
     - Measures latency with perf_counter precision
     - Records metrics
+    - Performs schema drift detection (non-blocking alerts)
     - Returns response with circuit breaker signal
     """
     agent_id = request.agent_id or "default"
     perf_start = time.perf_counter()
-    start_time = time.time()
 
     # Circuit breaker check
     breaker_reg = get_breaker_registry()
@@ -179,7 +297,7 @@ async def proxy_request(
 
     try:
         # Validate service
-        _get_service_config(request.service)
+        service_config = _get_service_config(request.service)
 
         # Build URL
         url = _build_url(request.service, request.path)
@@ -234,9 +352,46 @@ async def proxy_request(
 
         # Parse response body
         try:
-            response_body = proxied_response.json()
+            response_body: Any = proxied_response.json()
         except Exception:
             response_body = proxied_response.text
+
+        # Schema detection (non-blocking alert dispatch)
+        schema_endpoint = _schema_endpoint_key(agent_id, request.path)
+        fingerprint = fingerprint_response(
+            response_body,
+            status_code=proxied_response.status_code,
+            headers=proxied_response.headers,
+            latency_ms=latency_ms,
+        )
+        detector = get_schema_detector()
+        detection = detector.detect_changes(
+            request.service,
+            schema_endpoint,
+            fingerprint,
+            status_code=proxied_response.status_code,
+        )
+
+        _append_schema_events(
+            service=request.service,
+            endpoint=schema_endpoint,
+            fingerprint=fingerprint,
+            status_code=proxied_response.status_code,
+            changes=detection.changes,
+            warnings=detection.warnings,
+        )
+
+        if detection.changes and detector.alert_required(
+            detection.changes,
+            include_non_breaking=(service_config.get("schema_alert_mode") == "all"),
+        ):
+            background_tasks.add_task(
+                _dispatch_schema_alert_task,
+                service=request.service,
+                endpoint=schema_endpoint,
+                changes=detection.changes,
+                alert_mode=str(service_config.get("schema_alert_mode", "breaking_only")),
+            )
 
         return ProxyResponse(
             status_code=proxied_response.status_code,
@@ -364,6 +519,96 @@ async def proxy_metrics(service: str, agent_id: str = "default") -> dict:
                 "utilization": round(pool_metrics.utilization, 3) if pool_metrics else 0.0,
                 "reuse_ratio": round(pool_metrics.reuse_ratio, 3) if pool_metrics else 0.0,
             },
+        },
+        "error": None,
+    }
+
+
+@admin_router.get("/admin/schema/{service}/{endpoint:path}")
+async def get_schema_snapshot(
+    service: str,
+    endpoint: str,
+    agent_id: str = Query(default="default"),
+    limit: int = Query(default=5, ge=1, le=50),
+) -> dict[str, Any]:
+    """Return latest schema fingerprint and recent change history."""
+    _get_service_config(service)
+
+    detector = get_schema_detector()
+    schema_endpoint = _schema_endpoint_key(agent_id, endpoint)
+    fingerprint = detector.get_latest_fingerprint(service, schema_endpoint, status_code=200)
+    history = detector.get_change_history(
+        service,
+        schema_endpoint,
+        limit=limit,
+        status_code=200,
+    )
+
+    recent_events = [
+        event
+        for event in reversed(_schema_events)
+        if event.get("service") == service and event.get("endpoint") == schema_endpoint
+    ][:limit]
+
+    return {
+        "data": {
+            "service": service,
+            "endpoint": endpoint,
+            "agent_id": agent_id,
+            "latest_fingerprint": {
+                "hash": fingerprint.fingerprint_hash if fingerprint else None,
+                "schema_tree": fingerprint.schema_tree if fingerprint else None,
+                "max_depth": fingerprint.max_depth if fingerprint else 0,
+            },
+            "changes": [
+                {
+                    "change_type": change.change_type,
+                    "path": change.path,
+                    "severity": change.severity,
+                    "old_type": change.old_type,
+                    "new_type": change.new_type,
+                    "detail": change.detail,
+                    "similarity": change.similarity,
+                }
+                for change in history
+            ],
+            "events": recent_events,
+        },
+        "error": None,
+    }
+
+
+@admin_router.get("/admin/schema-alerts")
+async def list_schema_alerts(
+    service: str | None = Query(default=None),
+    severity: str | None = Query(default=None),
+    limit: int = Query(default=10, ge=1, le=100),
+) -> dict[str, Any]:
+    """Query recent schema alerts (in-app channel)."""
+    dispatcher = get_schema_alert_dispatcher()
+    alerts = dispatcher.query_alerts(service=service, severity=severity, limit=limit)
+
+    return {
+        "data": {
+            "alerts": [
+                {
+                    "alert_id": alert.alert_id,
+                    "service": alert.service,
+                    "endpoint": alert.endpoint,
+                    "severity": alert.severity,
+                    "change_detail": alert.change_detail,
+                    "alert_sent_at": (
+                        alert.alert_sent_at.isoformat() if alert.alert_sent_at else None
+                    ),
+                    "webhook_url": alert.webhook_url,
+                    "webhook_status": alert.webhook_status,
+                    "retry_count": alert.retry_count,
+                    "retry_at": alert.retry_at.isoformat() if alert.retry_at else None,
+                    "created_at": alert.created_at.isoformat(),
+                }
+                for alert in alerts
+            ],
+            "count": len(alerts),
         },
         "error": None,
     }

--- a/packages/api/services/schema_alert_pipeline.py
+++ b/packages/api/services/schema_alert_pipeline.py
@@ -1,0 +1,325 @@
+"""Schema change alert routing and deduplication pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from hashlib import sha256
+from typing import Any
+
+import httpx
+
+from services.schema_change_detector import SchemaChange
+
+
+@dataclass(frozen=True, slots=True)
+class AlertRecord:
+    """In-app alert record persisted for admin queries."""
+
+    alert_id: str
+    service: str
+    endpoint: str
+    severity: str
+    change_detail: dict[str, Any]
+    alert_sent_at: datetime | None
+    webhook_url: str | None
+    webhook_status: int | None
+    retry_count: int
+    retry_at: datetime | None
+    created_at: datetime
+
+
+class AlertDispatcher:
+    """Dispatch schema alerts to webhook, email, and in-app channels."""
+
+    def __init__(
+        self,
+        *,
+        webhook_timeout_seconds: float = 3.0,
+        dedupe_window_hours: int = 24,
+    ) -> None:
+        self._webhook_timeout = webhook_timeout_seconds
+        self._dedupe_window = timedelta(hours=dedupe_window_hours)
+        self._alerts: list[AlertRecord] = []
+        self._dedupe_index: dict[str, tuple[datetime, str]] = {}
+        self._email_log: list[dict[str, Any]] = []
+
+    @staticmethod
+    def _severity_rank(severity: str) -> int:
+        ranks = {"advisory": 0, "non_breaking": 1, "breaking": 2}
+        return ranks.get(severity, 0)
+
+    def _dedupe_key(
+        self,
+        service: str,
+        endpoint: str,
+        changes: tuple[SchemaChange, ...],
+    ) -> str:
+        normalized = "|".join(
+            sorted(
+                f"{change.change_type}:{change.path}:{change.old_type}:{change.new_type}"
+                for change in changes
+            )
+        )
+        payload = f"{service}:{endpoint}:{normalized}"
+        return sha256(payload.encode("utf-8")).hexdigest()
+
+    async def dispatch(
+        self,
+        *,
+        service: str,
+        endpoint: str,
+        changes: tuple[SchemaChange, ...],
+        webhook_url: str | None = None,
+        webhook_token: str | None = None,
+        alert_mode: str = "breaking_only",
+    ) -> dict[str, Any]:
+        """Route alert across destinations with dedupe and retries."""
+        highest_severity = self._highest_severity(changes)
+        if highest_severity == "advisory":
+            return {"status": "skipped", "reason": "advisory_only"}
+
+        if highest_severity == "non_breaking" and alert_mode != "all":
+            return {"status": "skipped", "reason": "non_breaking_filtered"}
+
+        dedupe_key = self._dedupe_key(service, endpoint, changes)
+        now = datetime.now(tz=UTC)
+        existing = self._dedupe_index.get(dedupe_key)
+        if existing is not None:
+            last_sent_at, previous_severity = existing
+            if now - last_sent_at < self._dedupe_window:
+                if self._severity_rank(highest_severity) <= self._severity_rank(previous_severity):
+                    return {"status": "deduped"}
+
+        payload = self._build_payload(service, endpoint, changes, highest_severity, now)
+        webhook_result = await self.webhook_dispatch(
+            payload=payload,
+            webhook_url=webhook_url,
+            webhook_token=webhook_token,
+        )
+        email_result = self.email_dispatch(
+            service=service,
+            endpoint=endpoint,
+            severity=highest_severity,
+        )
+        inapp_record = self.inapp_dispatch(
+            service=service,
+            endpoint=endpoint,
+            severity=highest_severity,
+            change_detail=payload,
+            webhook_url=webhook_url,
+            webhook_status=webhook_result["status_code"],
+            retry_count=webhook_result["retry_count"],
+            retry_at=webhook_result["retry_at"],
+            sent=webhook_result["sent"],
+        )
+
+        self._dedupe_index[dedupe_key] = (now, highest_severity)
+
+        return {
+            "status": "sent" if webhook_result["sent"] else "pending",
+            "payload": payload,
+            "webhook": webhook_result,
+            "email": email_result,
+            "alert_id": inapp_record.alert_id,
+        }
+
+    @staticmethod
+    def _highest_severity(changes: tuple[SchemaChange, ...]) -> str:
+        severities = [change.severity for change in changes]
+        if "breaking" in severities:
+            return "breaking"
+        if "non_breaking" in severities:
+            return "non_breaking"
+        return "advisory"
+
+    @staticmethod
+    def _build_payload(
+        service: str,
+        endpoint: str,
+        changes: tuple[SchemaChange, ...],
+        severity: str,
+        timestamp: datetime,
+    ) -> dict[str, Any]:
+        return {
+            "service": service,
+            "endpoint": endpoint,
+            "severity": severity,
+            "timestamp": timestamp.isoformat(),
+            "changes": [
+                {
+                    "change_type": change.change_type,
+                    "path": change.path,
+                    "old_type": change.old_type,
+                    "new_type": change.new_type,
+                    "detail": change.detail,
+                    "similarity": change.similarity,
+                    "severity": change.severity,
+                }
+                for change in changes
+            ],
+        }
+
+    async def webhook_dispatch(
+        self,
+        *,
+        payload: dict[str, Any],
+        webhook_url: str | None,
+        webhook_token: str | None,
+    ) -> dict[str, Any]:
+        """POST alert payload to operator webhook with retry scheduling."""
+        if not webhook_url:
+            return {
+                "sent": False,
+                "status_code": None,
+                "retry_count": 0,
+                "retry_at": None,
+            }
+
+        headers = {"Content-Type": "application/json"}
+        if webhook_token:
+            headers["Authorization"] = f"Bearer {webhook_token}"
+
+        try:
+            async with httpx.AsyncClient(timeout=self._webhook_timeout) as client:
+                response = await client.post(webhook_url, json=payload, headers=headers)
+            if 200 <= response.status_code < 300:
+                return {
+                    "sent": True,
+                    "status_code": int(response.status_code),
+                    "retry_count": 0,
+                    "retry_at": None,
+                }
+
+            retry_count = 1
+            retry_at = self._compute_retry_at(retry_count)
+            return {
+                "sent": False,
+                "status_code": int(response.status_code),
+                "retry_count": retry_count,
+                "retry_at": retry_at,
+            }
+        except Exception:
+            retry_count = 1
+            retry_at = self._compute_retry_at(retry_count)
+            return {
+                "sent": False,
+                "status_code": 500,
+                "retry_count": retry_count,
+                "retry_at": retry_at,
+            }
+
+    def email_dispatch(self, *, service: str, endpoint: str, severity: str) -> dict[str, Any]:
+        """Mock email/Slack dispatch for Phase 2."""
+        record = {
+            "service": service,
+            "endpoint": endpoint,
+            "severity": severity,
+            "recipient": "operators@rhumb.dev",
+            "timestamp": datetime.now(tz=UTC).isoformat(),
+        }
+        self._email_log.append(record)
+        return {"sent": True, "recipient": record["recipient"]}
+
+    def inapp_dispatch(
+        self,
+        *,
+        service: str,
+        endpoint: str,
+        severity: str,
+        change_detail: dict[str, Any],
+        webhook_url: str | None,
+        webhook_status: int | None,
+        retry_count: int,
+        retry_at: datetime | None,
+        sent: bool,
+    ) -> AlertRecord:
+        """Persist in-app alert record."""
+        now = datetime.now(tz=UTC)
+        digest = sha256(f"{service}:{endpoint}:{now.timestamp()}".encode("utf-8")).hexdigest()[:16]
+        record = AlertRecord(
+            alert_id=digest,
+            service=service,
+            endpoint=endpoint,
+            severity=severity,
+            change_detail=change_detail,
+            alert_sent_at=now if sent else None,
+            webhook_url=webhook_url,
+            webhook_status=webhook_status,
+            retry_count=retry_count,
+            retry_at=retry_at,
+            created_at=now,
+        )
+        self._alerts.append(record)
+        return record
+
+    def _compute_retry_at(self, retry_count: int) -> datetime:
+        delay_seconds = min(3600, 60 * (2 ** max(0, retry_count - 1)))
+        return datetime.now(tz=UTC) + timedelta(seconds=delay_seconds)
+
+    def query_alerts(
+        self,
+        *,
+        service: str | None = None,
+        severity: str | None = None,
+        limit: int = 10,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> list[AlertRecord]:
+        """Query recent in-app schema alerts."""
+        filtered = self._alerts
+        if service:
+            filtered = [record for record in filtered if record.service == service]
+        if severity:
+            filtered = [record for record in filtered if record.severity == severity]
+        if start:
+            filtered = [record for record in filtered if record.created_at >= start]
+        if end:
+            filtered = [record for record in filtered if record.created_at <= end]
+
+        filtered = sorted(filtered, key=lambda item: item.created_at, reverse=True)
+        return filtered[: max(1, limit)]
+
+    def backdate_dedupe_for_test(
+        self,
+        service: str,
+        endpoint: str,
+        changes: tuple[SchemaChange, ...],
+        *,
+        hours_ago: int,
+        severity: str,
+    ) -> None:
+        """Backdate dedupe index (test helper)."""
+        key = self._dedupe_key(service, endpoint, changes)
+        self._dedupe_index[key] = (
+            datetime.now(tz=UTC) - timedelta(hours=hours_ago),
+            severity,
+        )
+
+
+_dispatcher_singleton: AlertDispatcher | None = None
+
+
+def get_alert_dispatcher() -> AlertDispatcher:
+    """Return singleton alert dispatcher."""
+    global _dispatcher_singleton
+    if _dispatcher_singleton is None:
+        _dispatcher_singleton = AlertDispatcher()
+    return _dispatcher_singleton
+
+
+def reset_alert_dispatcher() -> None:
+    """Reset singleton dispatcher for tests."""
+    global _dispatcher_singleton
+    _dispatcher_singleton = None
+
+
+async def dispatch_async(*, dispatcher: AlertDispatcher, kwargs: dict[str, Any]) -> None:
+    """Background helper for fire-and-forget dispatch."""
+    await dispatcher.dispatch(**kwargs)
+
+
+def schedule_dispatch(dispatcher: AlertDispatcher, kwargs: dict[str, Any]) -> None:
+    """Schedule async dispatch without blocking caller."""
+    asyncio.create_task(dispatch_async(dispatcher=dispatcher, kwargs=kwargs))

--- a/packages/api/services/schema_change_detector.py
+++ b/packages/api/services/schema_change_detector.py
@@ -1,0 +1,438 @@
+"""Schema change detection and baseline tracking."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from services.schema_fingerprint import SchemaDiff, SchemaFingerprint, compare_schema_structures
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaChange:
+    """Single detected schema change."""
+
+    change_type: str
+    path: str
+    severity: str
+    old_type: str | None = None
+    new_type: str | None = None
+    detail: str | None = None
+    similarity: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DetectionResult:
+    """Result of comparing a candidate fingerprint against baseline."""
+
+    changes: tuple[SchemaChange, ...]
+    warnings: tuple[str, ...]
+    baseline_hash: str | None
+    current_hash: str
+    baseline_age_days: float | None
+
+
+@dataclass(slots=True)
+class BaselineEntry:
+    """Stored baseline fingerprint metadata."""
+
+    fingerprint: SchemaFingerprint
+    fingerprint_hash: str
+    captured_at: datetime
+
+
+class SchemaChangeDetector:
+    """Compares fingerprints and classifies schema drift severity."""
+
+    def __init__(
+        self,
+        *,
+        redis_client: Any = None,
+        stale_days: int = 7,
+    ) -> None:
+        self._redis = redis_client
+        self._stale_days = stale_days
+        self._baselines: dict[str, BaselineEntry] = {}
+        self._history: dict[str, list[SchemaChange]] = {}
+        self._last_change_at: dict[str, datetime] = {}
+        self._diff_cache: dict[tuple[str, str], tuple[SchemaChange, ...]] = {}
+
+    @staticmethod
+    def _status_bucket(status_code: int) -> str:
+        if status_code == 429:
+            return "rate_limited"
+        if 200 <= status_code < 400:
+            return "success"
+        return "error"
+
+    def _baseline_key(self, service: str, endpoint: str, status_code: int) -> str:
+        bucket = self._status_bucket(status_code)
+        clean_endpoint = endpoint.lstrip("/")
+        return f"schema:baseline:{service}:{clean_endpoint}:{bucket}"
+
+    def _history_key(self, service: str, endpoint: str, status_code: int = 200) -> str:
+        bucket = self._status_bucket(status_code)
+        clean_endpoint = endpoint.lstrip("/")
+        return f"schema:history:{service}:{clean_endpoint}:{bucket}"
+
+    def _service_history_key(self, service: str) -> str:
+        return f"schema:service:{service}"
+
+    def _set_baseline(self, key: str, fingerprint: SchemaFingerprint) -> None:
+        now = datetime.now(tz=UTC)
+        self._baselines[key] = BaselineEntry(
+            fingerprint=fingerprint,
+            fingerprint_hash=fingerprint.fingerprint_hash,
+            captured_at=now,
+        )
+
+        if self._redis is None:
+            return
+
+        try:
+            payload = {
+                "fingerprint_hash": fingerprint.fingerprint_hash,
+                "captured_at": now.isoformat(),
+                "schema_tree": fingerprint.schema_tree,
+            }
+            self._redis.set(key, json.dumps(payload))
+        except Exception:
+            # Graceful degradation: in-memory baseline remains source of truth.
+            return
+
+    def _get_baseline(self, key: str) -> BaselineEntry | None:
+        baseline = self._baselines.get(key)
+        if baseline is not None:
+            return baseline
+
+        if self._redis is None:
+            return None
+
+        try:
+            raw = self._redis.get(key)
+        except Exception:
+            return None
+
+        if not raw:
+            return None
+
+        try:
+            if isinstance(raw, bytes):
+                raw = raw.decode("utf-8")
+            payload = json.loads(raw)
+            schema_tree = payload.get("schema_tree")
+            fingerprint_hash = payload.get("fingerprint_hash")
+            captured_at_raw = payload.get("captured_at")
+            if not isinstance(schema_tree, dict) or not isinstance(fingerprint_hash, str):
+                return None
+            captured_at = datetime.fromisoformat(str(captured_at_raw))
+            if captured_at.tzinfo is None:
+                captured_at = captured_at.replace(tzinfo=UTC)
+
+            fingerprint = SchemaFingerprint(
+                schema_tree=schema_tree,
+                fingerprint_hash=fingerprint_hash,
+                field_paths=tuple(),
+                max_depth=1,
+                metadata=self._empty_metadata(),
+            )
+            baseline = BaselineEntry(
+                fingerprint=fingerprint,
+                fingerprint_hash=fingerprint_hash,
+                captured_at=captured_at,
+            )
+            self._baselines[key] = baseline
+            return baseline
+        except Exception:
+            return None
+
+    @staticmethod
+    def _empty_metadata() -> Any:
+        from services.schema_fingerprint import SchemaMetadata
+
+        return SchemaMetadata(
+            status_code=0,
+            latency_ms=0.0,
+            content_type=None,
+            cache_control=None,
+        )
+
+    def update_baseline(
+        self,
+        service: str,
+        endpoint: str,
+        fingerprint: SchemaFingerprint,
+        *,
+        status_code: int = 200,
+    ) -> None:
+        """Update baseline fingerprint for an endpoint."""
+        key = self._baseline_key(service, endpoint, status_code)
+        self._set_baseline(key, fingerprint)
+
+    def classify_severity(
+        self,
+        change_type: str,
+        *,
+        old_type: str | None = None,
+        new_type: str | None = None,
+    ) -> str:
+        """Classify change severity."""
+        if change_type in {"remove", "type_change", "nesting_change", "cardinality_change"}:
+            if change_type == "type_change" and {old_type, new_type} == {"null", "string"}:
+                return "non_breaking"
+            if change_type == "type_change" and {old_type, new_type} == {"null", "integer"}:
+                return "non_breaking"
+            if change_type == "type_change" and {old_type, new_type} == {"null", "number"}:
+                return "non_breaking"
+            if change_type == "type_change" and {old_type, new_type} == {"null", "boolean"}:
+                return "non_breaking"
+            return "breaking"
+
+        if change_type in {"add", "optional_change"}:
+            return "non_breaking"
+
+        if change_type in {"rename", "naming_change"}:
+            return "advisory"
+
+        return "advisory"
+
+    def alert_required(
+        self,
+        changes: tuple[SchemaChange, ...],
+        *,
+        include_non_breaking: bool = False,
+    ) -> bool:
+        """Decide if detected changes should trigger alerts."""
+        if any(change.severity == "breaking" for change in changes):
+            return True
+        if include_non_breaking and any(change.severity == "non_breaking" for change in changes):
+            return True
+        return False
+
+    def detect_changes(
+        self,
+        service: str,
+        endpoint: str,
+        current: SchemaFingerprint,
+        *,
+        status_code: int = 200,
+    ) -> DetectionResult:
+        """Compare current fingerprint with baseline for an endpoint."""
+        if status_code == 429:
+            return DetectionResult(
+                changes=tuple(),
+                warnings=("rate_limited_response_skipped",),
+                baseline_hash=None,
+                current_hash=current.fingerprint_hash,
+                baseline_age_days=None,
+            )
+
+        key = self._baseline_key(service, endpoint, status_code)
+        baseline = self._get_baseline(key)
+
+        if baseline is None:
+            self._set_baseline(key, current)
+            return DetectionResult(
+                changes=tuple(),
+                warnings=("baseline_created",),
+                baseline_hash=None,
+                current_hash=current.fingerprint_hash,
+                baseline_age_days=None,
+            )
+
+        baseline_age_days = (
+            datetime.now(tz=UTC) - baseline.captured_at
+        ).total_seconds() / 86400.0
+
+        warnings: list[str] = []
+        if baseline_age_days > float(self._stale_days):
+            warnings.append("baseline_stale")
+
+        if baseline.fingerprint_hash == current.fingerprint_hash:
+            self._set_baseline(key, current)
+            return DetectionResult(
+                changes=tuple(),
+                warnings=tuple(warnings),
+                baseline_hash=baseline.fingerprint_hash,
+                current_hash=current.fingerprint_hash,
+                baseline_age_days=baseline_age_days,
+            )
+
+        cache_key = (baseline.fingerprint_hash, current.fingerprint_hash)
+        cached = self._diff_cache.get(cache_key)
+        if cached is not None:
+            changes = cached
+        else:
+            diff = compare_schema_structures(baseline.fingerprint.schema_tree, current.schema_tree)
+            changes = self._changes_from_diff(diff)
+            self._diff_cache[cache_key] = changes
+
+        self._record_history(service, endpoint, changes, status_code)
+        self._set_baseline(key, current)
+
+        return DetectionResult(
+            changes=changes,
+            warnings=tuple(warnings),
+            baseline_hash=baseline.fingerprint_hash,
+            current_hash=current.fingerprint_hash,
+            baseline_age_days=baseline_age_days,
+        )
+
+    def _changes_from_diff(self, diff: SchemaDiff) -> tuple[SchemaChange, ...]:
+        changes: list[SchemaChange] = []
+
+        for path in diff.added_fields:
+            changes.append(
+                SchemaChange(
+                    change_type="add",
+                    path=path,
+                    severity=self.classify_severity("add"),
+                )
+            )
+
+        for path in diff.removed_fields:
+            changes.append(
+                SchemaChange(
+                    change_type="remove",
+                    path=path,
+                    severity=self.classify_severity("remove"),
+                )
+            )
+
+        for path, old_type, new_type in diff.type_changes:
+            change_type = "type_change"
+            if "null" in {old_type, new_type}:
+                change_type = "optional_change"
+            changes.append(
+                SchemaChange(
+                    change_type=change_type,
+                    path=path,
+                    old_type=old_type,
+                    new_type=new_type,
+                    severity=self.classify_severity(
+                        change_type,
+                        old_type=old_type,
+                        new_type=new_type,
+                    ),
+                )
+            )
+
+        for path, old_type, new_type in diff.nesting_changes:
+            changes.append(
+                SchemaChange(
+                    change_type="nesting_change",
+                    path=path,
+                    old_type=old_type,
+                    new_type=new_type,
+                    severity=self.classify_severity("nesting_change"),
+                )
+            )
+
+        for path, old_type, new_type in diff.cardinality_changes:
+            changes.append(
+                SchemaChange(
+                    change_type="cardinality_change",
+                    path=path,
+                    old_type=old_type,
+                    new_type=new_type,
+                    severity=self.classify_severity("cardinality_change"),
+                )
+            )
+
+        for rename in diff.likely_renames:
+            changes.append(
+                SchemaChange(
+                    change_type="rename",
+                    path=rename.old_field,
+                    detail=f"{rename.old_field} -> {rename.new_field}",
+                    similarity=rename.similarity,
+                    severity=self.classify_severity("rename"),
+                )
+            )
+
+        # Stable deterministic ordering for tests and reproducibility.
+        return tuple(sorted(changes, key=lambda c: (c.path, c.change_type)))
+
+    def _record_history(
+        self,
+        service: str,
+        endpoint: str,
+        changes: tuple[SchemaChange, ...],
+        status_code: int,
+    ) -> None:
+        key = self._history_key(service, endpoint, status_code)
+        bucket = self._history.setdefault(key, [])
+        bucket.extend(changes)
+
+        if any(change.severity == "breaking" for change in changes):
+            self._last_change_at[self._service_history_key(service)] = datetime.now(tz=UTC)
+
+    def get_change_history(
+        self,
+        service: str,
+        endpoint: str,
+        *,
+        limit: int = 5,
+        status_code: int = 200,
+    ) -> tuple[SchemaChange, ...]:
+        """Get recent change history for an endpoint."""
+        key = self._history_key(service, endpoint, status_code)
+        history = self._history.get(key, [])
+        if not history:
+            return tuple()
+        return tuple(history[-max(1, limit) :])
+
+    def get_latest_fingerprint(
+        self,
+        service: str,
+        endpoint: str,
+        *,
+        status_code: int = 200,
+    ) -> SchemaFingerprint | None:
+        """Return current baseline fingerprint for an endpoint."""
+        key = self._baseline_key(service, endpoint, status_code)
+        baseline = self._get_baseline(key)
+        return baseline.fingerprint if baseline else None
+
+    def get_service_stability_days(self, service: str) -> float | None:
+        """Return number of days since last breaking schema change for service."""
+        key = self._service_history_key(service)
+        last_change = self._last_change_at.get(key)
+        if last_change is None:
+            # No known breaking change: treat as stable from tracker start.
+            return 30.0
+        return (datetime.now(tz=UTC) - last_change).total_seconds() / 86400.0
+
+    def age_baseline_for_test(
+        self,
+        service: str,
+        endpoint: str,
+        *,
+        days: int,
+        status_code: int = 200,
+    ) -> None:
+        """Backdate baseline (test helper)."""
+        key = self._baseline_key(service, endpoint, status_code)
+        baseline = self._baselines.get(key)
+        if baseline is None:
+            return
+        baseline.captured_at = datetime.now(tz=UTC) - timedelta(days=days)
+
+
+_detector_singleton: SchemaChangeDetector | None = None
+
+
+def get_schema_change_detector(redis_client: Any = None) -> SchemaChangeDetector:
+    """Return singleton schema change detector."""
+    global _detector_singleton
+    if _detector_singleton is None:
+        _detector_singleton = SchemaChangeDetector(redis_client=redis_client)
+    return _detector_singleton
+
+
+def reset_schema_change_detector() -> None:
+    """Reset singleton detector (test helper)."""
+    global _detector_singleton
+    _detector_singleton = None

--- a/packages/api/services/schema_fingerprint.py
+++ b/packages/api/services/schema_fingerprint.py
@@ -1,0 +1,340 @@
+"""Schema fingerprinting utilities for proxy response payloads."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaMetadata:
+    """Metadata captured alongside a schema fingerprint."""
+
+    status_code: int
+    latency_ms: float
+    content_type: str | None
+    cache_control: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class RenameHint:
+    """Potential rename mapping between removed and added fields."""
+
+    old_field: str
+    new_field: str
+    similarity: float
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaDiff:
+    """Structural diff between two normalized schema trees."""
+
+    added_fields: tuple[str, ...]
+    removed_fields: tuple[str, ...]
+    type_changes: tuple[tuple[str, str, str], ...]
+    nesting_changes: tuple[tuple[str, str, str], ...]
+    cardinality_changes: tuple[tuple[str, str, str], ...]
+    likely_renames: tuple[RenameHint, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaFingerprint:
+    """Content-agnostic schema fingerprint for a response payload."""
+
+    schema_tree: dict[str, Any]
+    fingerprint_hash: str
+    field_paths: tuple[str, ...]
+    max_depth: int
+    metadata: SchemaMetadata
+
+
+def fingerprint_response(
+    payload: Any,
+    *,
+    status_code: int = 200,
+    headers: Mapping[str, str] | None = None,
+    latency_ms: float = 0.0,
+) -> SchemaFingerprint:
+    """Create a stable fingerprint for a response payload.
+
+    The hash ignores scalar values and captures only structure and types.
+    """
+    schema_tree = _normalize_schema(payload)
+    canonical = _canonical_json(schema_tree)
+    fingerprint_hash = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    field_paths = tuple(sorted(_collect_field_paths(schema_tree)))
+
+    content_type: str | None = None
+    cache_control: str | None = None
+    if headers:
+        lowered = {str(k).lower(): str(v) for k, v in headers.items()}
+        content_type = lowered.get("content-type")
+        cache_control = lowered.get("cache-control")
+
+    return SchemaFingerprint(
+        schema_tree=schema_tree,
+        fingerprint_hash=fingerprint_hash,
+        field_paths=field_paths,
+        max_depth=_compute_max_depth(schema_tree),
+        metadata=SchemaMetadata(
+            status_code=int(status_code),
+            latency_ms=float(latency_ms),
+            content_type=content_type,
+            cache_control=cache_control,
+        ),
+    )
+
+
+def compare_schema_structures(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+) -> SchemaDiff:
+    """Compute deep structural differences between two schema trees."""
+    added: set[str] = set()
+    removed: set[str] = set()
+    type_changes: list[tuple[str, str, str]] = []
+    nesting_changes: list[tuple[str, str, str]] = []
+    cardinality_changes: list[tuple[str, str, str]] = []
+
+    def visit(old_node: dict[str, Any], new_node: dict[str, Any], path: str) -> None:
+        old_type = str(old_node.get("type", "unknown"))
+        new_type = str(new_node.get("type", "unknown"))
+
+        if old_type != new_type:
+            if "array" in (old_type, new_type):
+                cardinality_changes.append((path, old_type, new_type))
+                if "object" in (old_type, new_type):
+                    nesting_changes.append((path, old_type, new_type))
+                return
+            if {old_type, new_type} == {"object", "union"}:
+                nesting_changes.append((path, old_type, new_type))
+                return
+            type_changes.append((path, old_type, new_type))
+            return
+
+        if old_type == "object":
+            old_fields = old_node.get("fields", {})
+            new_fields = new_node.get("fields", {})
+            if not isinstance(old_fields, dict) or not isinstance(new_fields, dict):
+                return
+
+            old_keys = set(old_fields.keys())
+            new_keys = set(new_fields.keys())
+            for name in sorted(new_keys - old_keys):
+                added.add(f"{path}.{name}" if path != "$" else name)
+            for name in sorted(old_keys - new_keys):
+                removed.add(f"{path}.{name}" if path != "$" else name)
+
+            for name in sorted(old_keys & new_keys):
+                child_path = f"{path}.{name}" if path != "$" else name
+                old_child = old_fields.get(name)
+                new_child = new_fields.get(name)
+                if isinstance(old_child, dict) and isinstance(new_child, dict):
+                    visit(old_child, new_child, child_path)
+            return
+
+        if old_type == "array":
+            old_items = old_node.get("items")
+            new_items = new_node.get("items")
+            if isinstance(old_items, dict) and isinstance(new_items, dict):
+                visit(old_items, new_items, f"{path}[]")
+
+    visit(baseline, candidate, "$")
+    renames = detect_likely_renames(tuple(sorted(removed)), tuple(sorted(added)))
+
+    return SchemaDiff(
+        added_fields=tuple(sorted(added)),
+        removed_fields=tuple(sorted(removed)),
+        type_changes=tuple(sorted(type_changes)),
+        nesting_changes=tuple(sorted(nesting_changes)),
+        cardinality_changes=tuple(sorted(cardinality_changes)),
+        likely_renames=tuple(renames),
+    )
+
+
+def detect_likely_renames(
+    removed_fields: tuple[str, ...],
+    added_fields: tuple[str, ...],
+    *,
+    threshold: float = 0.8,
+) -> list[RenameHint]:
+    """Find likely field renames based on normalized name similarity."""
+    hints: list[RenameHint] = []
+
+    for old_path in removed_fields:
+        old_name = _leaf_name(old_path)
+        best_score = 0.0
+        best_new: str | None = None
+
+        for new_path in added_fields:
+            new_name = _leaf_name(new_path)
+            score = field_name_similarity(old_name, new_name)
+            if score > best_score:
+                best_score = score
+                best_new = new_path
+
+        if best_new is not None and best_score >= threshold:
+            hints.append(
+                RenameHint(
+                    old_field=old_path,
+                    new_field=best_new,
+                    similarity=round(best_score, 4),
+                )
+            )
+
+    return hints
+
+
+def field_name_similarity(old_name: str, new_name: str) -> float:
+    """Compute similarity between field names using normalized edit distance."""
+    old_norm = _normalize_name(old_name)
+    new_norm = _normalize_name(new_name)
+    if not old_norm or not new_norm:
+        return 0.0
+    if old_norm == new_norm:
+        return 1.0
+
+    score = SequenceMatcher(None, old_norm, new_norm).ratio()
+
+    old_tokens = _name_tokens(old_name)
+    new_tokens = _name_tokens(new_name)
+    if old_tokens and new_tokens and old_tokens[-1] == new_tokens[-1]:
+        score = max(score, 0.85)
+
+    return score
+
+
+def _normalize_schema(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        fields = {key: _normalize_schema(val) for key, val in sorted(value.items())}
+        return {
+            "type": "object",
+            "fields": fields,
+        }
+
+    if isinstance(value, list):
+        if not value:
+            return {"type": "array", "items": {"type": "unknown"}}
+
+        item_schemas = [_normalize_schema(item) for item in value]
+        merged = _merge_schema_nodes(item_schemas)
+        return {"type": "array", "items": merged}
+
+    if value is None:
+        return {"type": "null"}
+
+    if isinstance(value, bool):
+        return {"type": "boolean"}
+
+    if isinstance(value, int):
+        return {"type": "integer"}
+
+    if isinstance(value, float):
+        return {"type": "number"}
+
+    if isinstance(value, str):
+        return {"type": "string"}
+
+    return {"type": "unknown"}
+
+
+def _merge_schema_nodes(nodes: list[dict[str, Any]]) -> dict[str, Any]:
+    if not nodes:
+        return {"type": "unknown"}
+
+    first = nodes[0]
+    if all(node == first for node in nodes[1:]):
+        return first
+
+    node_types = {str(node.get("type", "unknown")) for node in nodes}
+    if len(node_types) == 1 and "object" in node_types:
+        all_keys: set[str] = set()
+        for node in nodes:
+            fields = node.get("fields", {})
+            if isinstance(fields, dict):
+                all_keys.update(fields.keys())
+
+        merged_fields: dict[str, dict[str, Any]] = {}
+        for key in sorted(all_keys):
+            children = []
+            for node in nodes:
+                fields = node.get("fields", {})
+                if isinstance(fields, dict) and key in fields:
+                    child = fields.get(key)
+                    if isinstance(child, dict):
+                        children.append(child)
+                else:
+                    children.append({"type": "null"})
+            merged_fields[key] = _merge_schema_nodes(children)
+        return {"type": "object", "fields": merged_fields}
+
+    unique_options = sorted({_canonical_json(node) for node in nodes})
+    return {
+        "type": "union",
+        "options": [json.loads(option) for option in unique_options],
+    }
+
+
+def _collect_field_paths(node: dict[str, Any], path: str = "$") -> set[str]:
+    fields: set[str] = set()
+    node_type = str(node.get("type", "unknown"))
+
+    if node_type == "object":
+        node_fields = node.get("fields", {})
+        if isinstance(node_fields, dict):
+            for key, child in node_fields.items():
+                child_path = f"{path}.{key}" if path != "$" else key
+                fields.add(child_path)
+                if isinstance(child, dict):
+                    fields.update(_collect_field_paths(child, child_path))
+    elif node_type == "array":
+        items = node.get("items")
+        if isinstance(items, dict):
+            fields.update(_collect_field_paths(items, f"{path}[]"))
+
+    return fields
+
+
+def _compute_max_depth(node: dict[str, Any], depth: int = 1) -> int:
+    node_type = str(node.get("type", "unknown"))
+    if node_type == "object":
+        node_fields = node.get("fields", {})
+        if not isinstance(node_fields, dict) or not node_fields:
+            return depth
+        return max(_compute_max_depth(child, depth + 1) for child in node_fields.values())
+    if node_type == "array":
+        items = node.get("items")
+        if isinstance(items, dict):
+            return _compute_max_depth(items, depth + 1)
+    if node_type == "union":
+        options = node.get("options", [])
+        if isinstance(options, list) and options:
+            depths = [
+                _compute_max_depth(option, depth + 1)
+                for option in options
+                if isinstance(option, dict)
+            ]
+            if depths:
+                return max(depths)
+    return depth
+
+
+def _canonical_json(node: dict[str, Any]) -> str:
+    return json.dumps(node, sort_keys=True, separators=(",", ":"))
+
+
+def _normalize_name(name: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", name.lower())
+
+
+def _name_tokens(name: str) -> list[str]:
+    return [token for token in re.split(r"[^a-z0-9]+", name.lower()) if token]
+
+
+def _leaf_name(path: str) -> str:
+    leaf = path.split(".")[-1]
+    return leaf.replace("[]", "")

--- a/packages/api/tests/test_proxy_schema_detection_integration.py
+++ b/packages/api/tests/test_proxy_schema_detection_integration.py
@@ -1,0 +1,294 @@
+"""Integration tests for Round 13 proxy schema detection (Module 4)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from routes.leaderboard import router as leaderboard_router  # noqa: E402
+from routes.proxy import admin_router as proxy_admin_router  # noqa: E402
+from routes.proxy import router as proxy_router  # noqa: E402
+
+
+@pytest.fixture
+def fresh_schema_state() -> None:
+    """Reset proxy/schema singletons and stores between tests."""
+    import routes.proxy as proxy_module
+    from services.schema_alert_pipeline import reset_alert_dispatcher
+    from services.schema_change_detector import reset_schema_change_detector
+
+    proxy_module._pool_manager = None
+    proxy_module._breaker_registry = None
+    proxy_module._latency_tracker = None
+    proxy_module._schema_detector = None
+    proxy_module._schema_alert_dispatcher = None
+    proxy_module._schema_events = []
+
+    reset_schema_change_detector()
+    reset_alert_dispatcher()
+
+
+@pytest.fixture
+def app(fresh_schema_state) -> FastAPI:
+    test_app = FastAPI()
+    test_app.include_router(proxy_router, prefix="/v1/proxy")
+    test_app.include_router(proxy_admin_router, prefix="/v1")
+    test_app.include_router(leaderboard_router, prefix="/v1")
+    return test_app
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+class TestProxySchemaIntegration:
+    """Proxy + schema detector + alert/admin endpoints."""
+
+    def test_proxy_stable_schema_response_unaffected_and_fingerprint_stored(
+        self, client: TestClient, httpx_mock
+    ) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.stripe.com/customers",
+            json={"id": "cus_1", "email": "a@example.com"},
+            status_code=200,
+            headers={"content-type": "application/json"},
+        )
+
+        response = client.post(
+            "/v1/proxy/",
+            json={"service": "stripe", "method": "GET", "path": "/customers"},
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["body"]["id"] == "cus_1"
+
+        admin = client.get("/v1/admin/schema/stripe/customers")
+        assert admin.status_code == 200
+        latest = admin.json()["data"]["latest_fingerprint"]
+        assert latest["hash"] is not None
+
+    def test_proxy_breaking_change_dispatches_alert_async(
+        self, client: TestClient, httpx_mock
+    ) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.stripe.com/customers",
+            json={"id": "cus_1", "email": "a@example.com"},
+            status_code=200,
+            headers={"content-type": "application/json"},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.stripe.com/customers",
+            json={"id": "cus_1"},
+            status_code=200,
+            headers={"content-type": "application/json"},
+        )
+
+        client.post("/v1/proxy/", json={"service": "stripe", "method": "GET", "path": "/customers"})
+        second = client.post(
+            "/v1/proxy/",
+            json={"service": "stripe", "method": "GET", "path": "/customers"},
+        )
+        assert second.status_code == 200
+
+        alerts = client.get("/v1/admin/schema-alerts?service=stripe&limit=10")
+        assert alerts.status_code == 200
+        assert alerts.json()["data"]["count"] >= 1
+
+    def test_multiple_calls_same_schema_reuses_baseline(self, client: TestClient, httpx_mock) -> None:
+        for _ in range(2):
+            httpx_mock.add_response(
+                method="GET",
+                url="https://api.stripe.com/payment-intents",
+                json={"id": "pi_1", "amount": 1000},
+                status_code=200,
+                headers={"content-type": "application/json"},
+            )
+
+        client.post(
+            "/v1/proxy/",
+            json={"service": "stripe", "method": "GET", "path": "/payment-intents"},
+        )
+        client.post(
+            "/v1/proxy/",
+            json={"service": "stripe", "method": "GET", "path": "/payment-intents"},
+        )
+
+        import routes.proxy as proxy_module
+
+        detector = proxy_module.get_schema_detector()
+        assert len(detector._diff_cache) == 0
+
+    def test_admin_schema_endpoint_returns_latest_fingerprint_and_history(
+        self, client: TestClient, httpx_mock
+    ) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.stripe.com/create-payment-intent",
+            json={"id": "pi_1", "amount": 1000},
+            status_code=200,
+            headers={"content-type": "application/json"},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.stripe.com/create-payment-intent",
+            json={"id": "pi_1", "amount": "1000", "currency": "usd"},
+            status_code=200,
+            headers={"content-type": "application/json"},
+        )
+
+        client.post(
+            "/v1/proxy/",
+            json={"service": "stripe", "method": "GET", "path": "/create-payment-intent"},
+        )
+        client.post(
+            "/v1/proxy/",
+            json={"service": "stripe", "method": "GET", "path": "/create-payment-intent"},
+        )
+
+        admin = client.get("/v1/admin/schema/stripe/create-payment-intent")
+        data = admin.json()["data"]
+        assert data["latest_fingerprint"]["hash"] is not None
+        assert len(data["changes"]) >= 1
+
+    def test_leaderboard_applies_schema_stability_multiplier(self, client: TestClient) -> None:
+        response = client.get("/v1/leaderboard/email?limit=1")
+        assert response.status_code == 200
+        items = response.json()["data"]["items"]
+        if items:
+            assert "freshness_multiplier" in items[0]
+            assert items[0]["freshness_multiplier"] >= 1.0
+
+    def test_breaking_change_webhook_payload_shape(self, client: TestClient, httpx_mock) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.stripe.com/invoices",
+            json={"id": "in_1", "customer": "cus_1"},
+            status_code=200,
+            headers={"content-type": "application/json"},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.stripe.com/invoices",
+            json={"id": "in_1"},
+            status_code=200,
+            headers={"content-type": "application/json"},
+        )
+
+        client.post("/v1/proxy/", json={"service": "stripe", "method": "GET", "path": "/invoices"})
+        client.post("/v1/proxy/", json={"service": "stripe", "method": "GET", "path": "/invoices"})
+
+        alerts = client.get("/v1/admin/schema-alerts?service=stripe&limit=1").json()["data"]["alerts"]
+        assert alerts
+        detail = alerts[0]["change_detail"]
+        assert detail["service"] == "stripe"
+        assert detail["endpoint"].startswith("default:")
+        assert detail["changes"]
+
+    def test_error_response_schema_isolated_from_success_baseline(
+        self, client: TestClient, httpx_mock
+    ) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.stripe.com/accounts",
+            json={"id": "acct_1", "email": "a@example.com"},
+            status_code=200,
+            headers={"content-type": "application/json"},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.stripe.com/accounts",
+            json={"error": {"message": "boom"}},
+            status_code=500,
+            headers={"content-type": "application/json"},
+        )
+
+        ok = client.post("/v1/proxy/", json={"service": "stripe", "method": "GET", "path": "/accounts"})
+        err = client.post("/v1/proxy/", json={"service": "stripe", "method": "GET", "path": "/accounts"})
+        assert ok.status_code == 200
+        assert err.status_code == 200
+
+        admin = client.get("/v1/admin/schema/stripe/accounts")
+        assert admin.status_code == 200
+        assert admin.json()["data"]["latest_fingerprint"]["hash"] is not None
+
+    def test_high_volume_calls_do_not_block_proxy(self, client: TestClient, httpx_mock) -> None:
+        for _ in range(100):
+            httpx_mock.add_response(
+                method="GET",
+                url="https://api.stripe.com/high-volume",
+                json={"ok": True, "id": "x"},
+                status_code=200,
+                headers={"content-type": "application/json"},
+            )
+
+        for _ in range(100):
+            response = client.post(
+                "/v1/proxy/",
+                json={"service": "stripe", "method": "GET", "path": "/high-volume"},
+            )
+            assert response.status_code == 200
+
+    def test_multi_tenant_alert_isolation(self, client: TestClient, httpx_mock) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.stripe.com/tenant-endpoint",
+            json={"id": "1", "email": "a@example.com"},
+            status_code=200,
+            headers={"content-type": "application/json"},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.stripe.com/tenant-endpoint",
+            json={"id": "1"},
+            status_code=200,
+            headers={"content-type": "application/json"},
+        )
+
+        client.post(
+            "/v1/proxy/",
+            json={"service": "stripe", "method": "GET", "path": "/tenant-endpoint", "agent_id": "agent-a"},
+        )
+        client.post(
+            "/v1/proxy/",
+            json={"service": "stripe", "method": "GET", "path": "/tenant-endpoint", "agent_id": "agent-a"},
+        )
+
+        schema_a = client.get("/v1/admin/schema/stripe/tenant-endpoint?agent_id=agent-a").json()["data"]
+        schema_b = client.get("/v1/admin/schema/stripe/tenant-endpoint?agent_id=agent-b").json()["data"]
+        assert schema_a["changes"]
+        assert not schema_b["changes"]
+
+    def test_admin_schema_alerts_query_filters(self, client: TestClient, httpx_mock) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.stripe.com/filter-alerts",
+            json={"id": "1", "email": "a@example.com"},
+            status_code=200,
+            headers={"content-type": "application/json"},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.stripe.com/filter-alerts",
+            json={"id": "1"},
+            status_code=200,
+            headers={"content-type": "application/json"},
+        )
+
+        client.post("/v1/proxy/", json={"service": "stripe", "method": "GET", "path": "/filter-alerts"})
+        client.post("/v1/proxy/", json={"service": "stripe", "method": "GET", "path": "/filter-alerts"})
+
+        response = client.get("/v1/admin/schema-alerts?service=stripe&severity=breaking&limit=10")
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["count"] >= 1
+        assert all(alert["service"] == "stripe" for alert in data["alerts"])

--- a/packages/api/tests/test_schema_alert_pipeline.py
+++ b/packages/api/tests/test_schema_alert_pipeline.py
@@ -1,0 +1,183 @@
+"""Tests for schema alert pipeline (Round 13 Module 3)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from services.schema_alert_pipeline import AlertDispatcher  # noqa: E402
+from services.schema_change_detector import SchemaChange  # noqa: E402
+
+
+def _breaking_changes() -> tuple[SchemaChange, ...]:
+    return (
+        SchemaChange(
+            change_type="remove",
+            path="customer.email",
+            severity="breaking",
+            old_type="string",
+            new_type=None,
+        ),
+    )
+
+
+def _non_breaking_changes() -> tuple[SchemaChange, ...]:
+    return (
+        SchemaChange(
+            change_type="add",
+            path="customer.nickname",
+            severity="non_breaking",
+            old_type=None,
+            new_type="string",
+        ),
+    )
+
+
+class TestSchemaAlertPipeline:
+    """Alert dispatcher behavior."""
+
+    @pytest.mark.asyncio
+    async def test_breaking_change_dispatches_webhook(self, httpx_mock) -> None:
+        dispatcher = AlertDispatcher()
+        httpx_mock.add_response(url="https://ops.example/webhook", status_code=200)
+
+        result = await dispatcher.dispatch(
+            service="stripe",
+            endpoint="default:v1/customers",
+            changes=_breaking_changes(),
+            webhook_url="https://ops.example/webhook",
+        )
+
+        assert result["status"] == "sent"
+        assert len(httpx_mock.get_requests()) == 1
+
+    @pytest.mark.asyncio
+    async def test_non_breaking_change_filtered_by_default(self, httpx_mock) -> None:
+        dispatcher = AlertDispatcher()
+
+        result = await dispatcher.dispatch(
+            service="stripe",
+            endpoint="default:v1/customers",
+            changes=_non_breaking_changes(),
+            webhook_url="https://ops.example/webhook",
+        )
+
+        assert result["status"] == "skipped"
+        assert result["reason"] == "non_breaking_filtered"
+        assert len(httpx_mock.get_requests()) == 0
+
+    @pytest.mark.asyncio
+    async def test_webhook_success_marked_sent(self, httpx_mock) -> None:
+        dispatcher = AlertDispatcher()
+        httpx_mock.add_response(url="https://ops.example/webhook", status_code=200)
+
+        result = await dispatcher.dispatch(
+            service="stripe",
+            endpoint="default:v1/customers",
+            changes=_breaking_changes(),
+            webhook_url="https://ops.example/webhook",
+        )
+
+        alert = dispatcher.query_alerts(limit=1)[0]
+        assert result["webhook"]["status_code"] == 200
+        assert alert.alert_sent_at is not None
+
+    @pytest.mark.asyncio
+    async def test_webhook_failure_schedules_retry(self, httpx_mock) -> None:
+        dispatcher = AlertDispatcher()
+        httpx_mock.add_response(url="https://ops.example/webhook", status_code=500)
+
+        result = await dispatcher.dispatch(
+            service="stripe",
+            endpoint="default:v1/customers",
+            changes=_breaking_changes(),
+            webhook_url="https://ops.example/webhook",
+        )
+
+        alert = dispatcher.query_alerts(limit=1)[0]
+        assert result["status"] == "pending"
+        assert alert.retry_count == 1
+        assert alert.retry_at is not None
+
+    @pytest.mark.asyncio
+    async def test_alert_dedup_within_window(self, httpx_mock) -> None:
+        dispatcher = AlertDispatcher()
+        httpx_mock.add_response(url="https://ops.example/webhook", status_code=200)
+
+        first = await dispatcher.dispatch(
+            service="stripe",
+            endpoint="default:v1/customers",
+            changes=_breaking_changes(),
+            webhook_url="https://ops.example/webhook",
+        )
+        second = await dispatcher.dispatch(
+            service="stripe",
+            endpoint="default:v1/customers",
+            changes=_breaking_changes(),
+            webhook_url="https://ops.example/webhook",
+        )
+
+        assert first["status"] == "sent"
+        assert second["status"] == "deduped"
+        assert len(httpx_mock.get_requests()) == 1
+
+    @pytest.mark.asyncio
+    async def test_payload_shape_includes_required_fields(self, httpx_mock) -> None:
+        dispatcher = AlertDispatcher()
+        httpx_mock.add_response(url="https://ops.example/webhook", status_code=200)
+
+        result = await dispatcher.dispatch(
+            service="stripe",
+            endpoint="default:v1/payment-intents",
+            changes=_breaking_changes(),
+            webhook_url="https://ops.example/webhook",
+            webhook_token="secret",
+        )
+
+        payload = result["payload"]
+        assert payload["service"] == "stripe"
+        assert payload["endpoint"] == "default:v1/payment-intents"
+        assert payload["severity"] == "breaking"
+        assert payload["changes"]
+
+    @pytest.mark.asyncio
+    async def test_email_dispatch_logged_with_recipient(self, httpx_mock) -> None:
+        dispatcher = AlertDispatcher()
+        httpx_mock.add_response(url="https://ops.example/webhook", status_code=200)
+
+        result = await dispatcher.dispatch(
+            service="stripe",
+            endpoint="default:v1/customers",
+            changes=_breaking_changes(),
+            webhook_url="https://ops.example/webhook",
+        )
+
+        assert result["email"]["sent"] is True
+        assert result["email"]["recipient"] == "operators@rhumb.dev"
+
+    @pytest.mark.asyncio
+    async def test_alert_query_filters_service_and_limit(self, httpx_mock) -> None:
+        dispatcher = AlertDispatcher()
+        httpx_mock.add_response(url="https://ops.example/webhook", status_code=200)
+        httpx_mock.add_response(url="https://ops.example/webhook", status_code=200)
+
+        await dispatcher.dispatch(
+            service="stripe",
+            endpoint="default:v1/customers",
+            changes=_breaking_changes(),
+            webhook_url="https://ops.example/webhook",
+        )
+        await dispatcher.dispatch(
+            service="github",
+            endpoint="default:repos",
+            changes=_breaking_changes(),
+            webhook_url="https://ops.example/webhook",
+        )
+
+        alerts = dispatcher.query_alerts(service="stripe", limit=10)
+        assert len(alerts) == 1
+        assert alerts[0].service == "stripe"

--- a/packages/api/tests/test_schema_change_detector.py
+++ b/packages/api/tests/test_schema_change_detector.py
@@ -1,0 +1,161 @@
+"""Tests for schema change detector (Round 13 Module 2)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from services.schema_change_detector import SchemaChangeDetector  # noqa: E402
+from services.schema_fingerprint import fingerprint_response  # noqa: E402
+
+
+class TestSchemaChangeDetector:
+    """Schema drift detector behavior and severity mapping."""
+
+    def test_no_changes_for_identical_response(self) -> None:
+        detector = SchemaChangeDetector()
+        fp = fingerprint_response({"id": "cus_123"})
+        detector.detect_changes("stripe", "default:v1/customers", fp)
+        result = detector.detect_changes("stripe", "default:v1/customers", fp)
+        assert result.changes == tuple()
+
+    def test_field_addition_non_breaking(self) -> None:
+        detector = SchemaChangeDetector()
+        detector.detect_changes("stripe", "default:v1/customers", fingerprint_response({"id": "1"}))
+        result = detector.detect_changes(
+            "stripe",
+            "default:v1/customers",
+            fingerprint_response({"id": "1", "email": "a@example.com"}),
+        )
+        assert any(change.change_type == "add" for change in result.changes)
+        assert all(change.severity != "breaking" for change in result.changes)
+
+    def test_field_removal_breaking(self) -> None:
+        detector = SchemaChangeDetector()
+        detector.detect_changes(
+            "stripe",
+            "default:v1/customers",
+            fingerprint_response({"id": "1", "email": "a@example.com"}),
+        )
+        result = detector.detect_changes("stripe", "default:v1/customers", fingerprint_response({"id": "1"}))
+        assert any(change.change_type == "remove" and change.severity == "breaking" for change in result.changes)
+
+    def test_type_change_breaking(self) -> None:
+        detector = SchemaChangeDetector()
+        detector.detect_changes("stripe", "default:v1/payment-intents", fingerprint_response({"amount": 1000}))
+        result = detector.detect_changes(
+            "stripe",
+            "default:v1/payment-intents",
+            fingerprint_response({"amount": "1000"}),
+        )
+        assert any(change.change_type == "type_change" and change.severity == "breaking" for change in result.changes)
+
+    def test_multiple_changes_detected_and_classified(self) -> None:
+        detector = SchemaChangeDetector()
+        detector.detect_changes(
+            "stripe",
+            "default:v1/charges",
+            fingerprint_response({"id": "1", "amount": 10, "meta": {"mode": "live"}}),
+        )
+        result = detector.detect_changes(
+            "stripe",
+            "default:v1/charges",
+            fingerprint_response({"id": "1", "total": "10", "meta": [{"mode": "live"}], "new_field": True}),
+        )
+        change_types = {change.change_type for change in result.changes}
+        assert "remove" in change_types
+        assert "add" in change_types
+        assert "nesting_change" in change_types or "cardinality_change" in change_types
+
+    def test_empty_response_handled_gracefully(self) -> None:
+        detector = SchemaChangeDetector()
+        first = detector.detect_changes("stripe", "default:v1/empty", fingerprint_response({}))
+        second = detector.detect_changes("stripe", "default:v1/empty", fingerprint_response({}))
+        assert "baseline_created" in first.warnings
+        assert second.changes == tuple()
+
+    def test_breaking_and_advisory_surface_together(self) -> None:
+        detector = SchemaChangeDetector()
+        detector.detect_changes(
+            "stripe",
+            "default:v1/invoices",
+            fingerprint_response({"customer_name": "A", "email": "a@x.com"}),
+        )
+        result = detector.detect_changes(
+            "stripe",
+            "default:v1/invoices",
+            fingerprint_response({"customername": "A"}),
+        )
+        severities = {change.severity for change in result.changes}
+        assert "breaking" in severities
+        assert "advisory" in severities
+
+    def test_baseline_update_flow(self) -> None:
+        detector = SchemaChangeDetector()
+        fp_a = fingerprint_response({"id": "1"})
+        fp_b = fingerprint_response({"id": "1", "email": "a@example.com"})
+        detector.update_baseline("stripe", "default:v1/customers", fp_a)
+        assert detector.get_latest_fingerprint("stripe", "default:v1/customers") is not None
+        detector.update_baseline("stripe", "default:v1/customers", fp_b)
+        latest = detector.get_latest_fingerprint("stripe", "default:v1/customers")
+        assert latest is not None
+        assert latest.fingerprint_hash == fp_b.fingerprint_hash
+
+    def test_stale_baseline_warning(self) -> None:
+        detector = SchemaChangeDetector()
+        detector.detect_changes("stripe", "default:v1/stale", fingerprint_response({"id": "1"}))
+        detector.age_baseline_for_test("stripe", "default:v1/stale", days=8)
+        result = detector.detect_changes("stripe", "default:v1/stale", fingerprint_response({"id": "1", "new": 1}))
+        assert "baseline_stale" in result.warnings
+
+    def test_non_json_response_graceful_fallback(self) -> None:
+        detector = SchemaChangeDetector()
+        html_fp = fingerprint_response("<html><body>error</body></html>")
+        detector.detect_changes("stripe", "default:v1/non-json", html_fp, status_code=500)
+        result = detector.detect_changes(
+            "stripe",
+            "default:v1/non-json",
+            fingerprint_response("<html><body>error2</body></html>"),
+            status_code=500,
+        )
+        assert result.changes == tuple()
+
+    def test_rate_limit_response_not_schema_drift(self) -> None:
+        detector = SchemaChangeDetector()
+        result = detector.detect_changes(
+            "stripe",
+            "default:v1/customers",
+            fingerprint_response({"error": "rate_limited"}),
+            status_code=429,
+        )
+        assert result.changes == tuple()
+        assert "rate_limited_response_skipped" in result.warnings
+
+    def test_error_schema_separate_from_success_schema(self) -> None:
+        detector = SchemaChangeDetector()
+        detector.detect_changes(
+            "stripe",
+            "default:v1/customers",
+            fingerprint_response({"id": "cus_1", "email": "a@example.com"}),
+            status_code=200,
+        )
+        detector.detect_changes(
+            "stripe",
+            "default:v1/customers",
+            fingerprint_response({"error": {"message": "boom"}}),
+            status_code=500,
+        )
+        success_fp = detector.get_latest_fingerprint(
+            "stripe",
+            "default:v1/customers",
+            status_code=200,
+        )
+        error_fp = detector.get_latest_fingerprint(
+            "stripe",
+            "default:v1/customers",
+            status_code=500,
+        )
+        assert success_fp is not None and error_fp is not None
+        assert success_fp.fingerprint_hash != error_fp.fingerprint_hash

--- a/packages/api/tests/test_schema_fingerprint.py
+++ b/packages/api/tests/test_schema_fingerprint.py
@@ -1,0 +1,90 @@
+"""Tests for schema fingerprinting engine (Round 13 Module 1)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from services.schema_fingerprint import (  # noqa: E402
+    compare_schema_structures,
+    detect_likely_renames,
+    field_name_similarity,
+    fingerprint_response,
+)
+
+
+class TestSchemaFingerprint:
+    """Schema fingerprint engine behavior."""
+
+    def test_fingerprint_stable_response_consistent_hash(self) -> None:
+        payload = {"id": "cus_123", "email": "a@example.com", "active": True}
+        fp1 = fingerprint_response(payload)
+        fp2 = fingerprint_response(payload)
+        assert fp1.fingerprint_hash == fp2.fingerprint_hash
+
+    def test_add_field_detected_as_change(self) -> None:
+        base = fingerprint_response({"id": "cus_123"})
+        changed = fingerprint_response({"id": "cus_123", "email": "a@example.com"})
+        diff = compare_schema_structures(base.schema_tree, changed.schema_tree)
+        assert "email" in diff.added_fields
+
+    def test_remove_field_detected_as_change(self) -> None:
+        base = fingerprint_response({"id": "cus_123", "email": "a@example.com"})
+        changed = fingerprint_response({"id": "cus_123"})
+        diff = compare_schema_structures(base.schema_tree, changed.schema_tree)
+        assert "email" in diff.removed_fields
+
+    def test_type_change_detected(self) -> None:
+        base = fingerprint_response({"amount": "1000"})
+        changed = fingerprint_response({"amount": 1000})
+        diff = compare_schema_structures(base.schema_tree, changed.schema_tree)
+        assert any(path == "amount" for path, _, _ in diff.type_changes)
+
+    def test_nested_object_structure_change_detected(self) -> None:
+        base = fingerprint_response({"customer": {"name": "A"}})
+        changed = fingerprint_response({"customer": [{"name": "A"}]})
+        diff = compare_schema_structures(base.schema_tree, changed.schema_tree)
+        assert any(path == "customer" for path, _, _ in diff.nesting_changes)
+
+    def test_order_insensitive_hash(self) -> None:
+        left = fingerprint_response({"a": 1, "b": 2, "c": 3})
+        right = fingerprint_response({"c": 3, "a": 1, "b": 2})
+        assert left.fingerprint_hash == right.fingerprint_hash
+
+    def test_semantic_rename_similarity_flags(self) -> None:
+        similarity = field_name_similarity("old_field", "new_field")
+        hints = detect_likely_renames(("old_field",), ("new_field",), threshold=0.8)
+        assert similarity > 0.8
+        assert hints and hints[0].similarity > 0.8
+
+    def test_null_optional_fields_tracked_as_type_delta(self) -> None:
+        base = fingerprint_response({"nickname": None})
+        changed = fingerprint_response({"nickname": "pedro"})
+        diff = compare_schema_structures(base.schema_tree, changed.schema_tree)
+        assert any(path == "nickname" for path, _, _ in diff.type_changes)
+
+    def test_array_single_object_change_detected(self) -> None:
+        base = fingerprint_response({"items": [{"id": "1"}]})
+        changed = fingerprint_response({"items": {"id": "1"}})
+        diff = compare_schema_structures(base.schema_tree, changed.schema_tree)
+        assert any(path == "items" for path, _, _ in diff.cardinality_changes)
+
+    def test_complex_nested_structure_fingerprinted(self) -> None:
+        payload = {
+            "data": {
+                "items": [
+                    {
+                        "id": "evt_1",
+                        "attributes": {
+                            "owner": {"id": "u_1", "name": "Tom"},
+                            "flags": [True, False],
+                        },
+                    }
+                ]
+            }
+        }
+        fp = fingerprint_response(payload)
+        assert fp.max_depth >= 4
+        assert "data.items[].attributes.owner.id" in fp.field_paths


### PR DESCRIPTION
## Summary
Implements Round 13 (WU 2.4) schema change detection end-to-end for proxy responses, including fingerprinting, change classification, alert routing, admin query endpoints, and migration scaffolding.

## What shipped
### 1) `schema_fingerprint.py`
- Deterministic schema fingerprinting (order-insensitive, value-agnostic)
- Deep schema normalization for objects/arrays/unions
- Structural diffing: add/remove/type/nesting/cardinality changes
- Semantic rename hints via field-name similarity
- Metadata capture (status, latency, content-type, cache-control)

### 2) `schema_change_detector.py`
- Baseline tracking per `service + endpoint + status bucket`
- Classification into `breaking`, `non_breaking`, `advisory`
- Handles 429 responses as non-drift
- Separates success/error schema baselines
- Stale baseline warning (`>7 days`)
- Diff cache to avoid repeated recomputation

### 3) `schema_alert_pipeline.py`
- Webhook + email + in-app alert routing
- 24h dedupe window by change signature
- Retry scheduling with exponential backoff metadata
- Service/severity/limit query support for in-app alert history

### 4) Proxy + admin integration
- Extended `routes/proxy.py` to run schema detection on proxied responses
- Non-blocking alert dispatch through FastAPI `BackgroundTasks`
- Added admin endpoints:
  - `GET /v1/admin/schema/{service}/{endpoint}`
  - `GET /v1/admin/schema-alerts`
- Added multi-tenant endpoint-key isolation via `agent_id`

### 5) Supabase migration
- Added idempotent migration: `packages/api/migrations/0007_schema_detection.sql`
- Creates `schema_fingerprints`, `schema_events`, `schema_alerts` with indexes

## Tests
### New Round 13 tests (40 total)
- `test_schema_fingerprint.py` → **10**
- `test_schema_change_detector.py` → **12**
- `test_schema_alert_pipeline.py` → **8**
- `test_proxy_schema_detection_integration.py` → **10**

Run:
```bash
cd packages/api
pytest tests/test_schema_fingerprint.py tests/test_schema_change_detector.py tests/test_schema_alert_pipeline.py tests/test_proxy_schema_detection_integration.py
```
Result: **40 passed**

### Regression run
```bash
cd packages/api
pytest -k 'not leaderboard_search and not proxy_benchmarks'
```
Result: **341 passed, 21 deselected**

## Type checking
```bash
./.venv/bin/python -m mypy --follow-imports=skip \
  packages/api/services/schema_fingerprint.py \
  packages/api/services/schema_change_detector.py \
  packages/api/services/schema_alert_pipeline.py \
  packages/api/routes/proxy.py \
  packages/api/routes/leaderboard.py
```
Result: **Success: no issues found**

## Notes
- Full `packages/api` run currently has 2 pre-existing failing buckets (`test_leaderboard_search`, `test_proxy_benchmarks`) unrelated to this Round 13 change set.
- This PR does **not** merge; ready for Pedro review + merge to `main`.
