### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Most APIs weren't built for agents. Rhumb helps agents and operators see which t
 
 🌐 [rhumb.dev](https://rhumb.dev) · ⚡ [Quickstart](https://rhumb.dev/quickstart) · 💵 [Pricing](https://rhumb.dev/pricing) · 📊 [Leaderboard](https://rhumb.dev/leaderboard) · 📖 [Methodology](https://rhumb.dev/methodology) · 🔑 [Trust](https://rhumb.dev/trust) · 🔌 [npm: rhumb-mcp](https://www.npmjs.com/package/rhumb-mcp)
 
+[![Rhumb MCP server](https://glama.ai/mcp/servers/supertrained/rhumb/badges/card.svg)](https://glama.ai/mcp/servers/supertrained/rhumb)
+
 ## What is Rhumb?
 
 Rhumb is the infrastructure layer agents use to **discover, access, and trust** external tools.


### PR DESCRIPTION
This PR adds a badge for the [Rhumb](https://glama.ai/mcp/servers/supertrained/rhumb) server listing in Glama MCP server directory.

[![Rhumb MCP server](https://glama.ai/mcp/servers/supertrained/rhumb/badges/card.svg)](https://glama.ai/mcp/servers/supertrained/rhumb)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.