### PR TITLE
fix(aud-18): add auth_handoff to direct execute GET

### DIFF
--- a/packages/api/routes/capability_execute.py
+++ b/packages/api/routes/capability_execute.py
@@ -405,6 +405,11 @@ def _direct_execute_get_not_supported_response(
             "execute_url": execute_url,
             "resolve_url": _capability_resolve_url(capability_id),
             "credential_modes_url": _capability_credential_modes_url(capability_id),
+            "auth_handoff": _execute_auth_handoff(
+                capability_id,
+                supported_paths=("governed_api_key",),
+                reason="post_required",
+            ),
         },
     )
 

--- a/packages/api/routes/capability_execute.py
+++ b/packages/api/routes/capability_execute.py
@@ -362,6 +362,7 @@ def _direct_execute_auth_required_response(
 ) -> JSONResponse:
     """Return a structured auth handoff for direct execute rails that require API keys."""
     request_id = getattr(raw_request.state, "request_id", None) or str(uuid.uuid4())
+    execute_url = f"/v1/capabilities/{quote(capability_id, safe='')}/execute"
     return JSONResponse(
         status_code=401,
         content={
@@ -373,6 +374,7 @@ def _direct_execute_auth_required_response(
                 "to inspect the current preferred rail."
             ),
             "request_id": request_id,
+            "execute_url": execute_url,
             "resolve_url": _capability_resolve_url(capability_id),
             "credential_modes_url": _capability_credential_modes_url(capability_id),
             "auth_handoff": _execute_auth_handoff(
@@ -420,6 +422,7 @@ def _direct_execute_estimate_readiness(capability_id: str) -> dict[str, Any] | N
     detail = _direct_execute_auth_detail(capability_id)
     if detail is None:
         return None
+    execute_url = f"/v1/capabilities/{quote(capability_id, safe='')}/execute"
     return {
         "status": "auth_required",
         "message": detail,
@@ -428,6 +431,7 @@ def _direct_execute_estimate_readiness(capability_id: str) -> dict[str, Any] | N
             "this execute call with X-Rhumb-Key. Use resolve first if you need "
             "to inspect the current preferred rail."
         ),
+        "execute_url": execute_url,
         "resolve_url": _capability_resolve_url(capability_id),
         "credential_modes_url": _capability_credential_modes_url(capability_id),
         "auth_handoff": _execute_auth_handoff(

--- a/packages/api/routes/capability_execute.py
+++ b/packages/api/routes/capability_execute.py
@@ -394,6 +394,7 @@ def _direct_execute_get_not_supported_response(
     execute_url = f"/v1/capabilities/{quote(capability_id, safe='')}/execute"
     return JSONResponse(
         status_code=405,
+        headers={"Allow": "POST"},
         content={
             "error": "method_not_allowed",
             "message": "Direct capability execute discovery is POST-only after API-key auth.",

--- a/packages/api/tests/test_capability_execute.py
+++ b/packages/api/tests/test_capability_execute.py
@@ -4178,6 +4178,10 @@ async def test_direct_execute_get_with_api_key_returns_post_only_guidance(app):
     assert body["execute_url"] == "/v1/capabilities/crm.object.describe/execute"
     assert body["resolve_url"] == "/v1/capabilities/crm.object.describe/resolve"
     assert body["credential_modes_url"] == "/v1/capabilities/crm.object.describe/credential-modes"
+    assert body["auth_handoff"]["reason"] == "post_required"
+    assert body["auth_handoff"]["recommended_path"] == "governed_api_key"
+    auth_paths = {item["kind"]: item for item in body["auth_handoff"]["paths"]}
+    assert set(auth_paths) == {"governed_api_key"}
 
 
 @pytest.mark.anyio

--- a/packages/api/tests/test_capability_execute.py
+++ b/packages/api/tests/test_capability_execute.py
@@ -4156,6 +4156,7 @@ async def test_direct_execute_get_requires_api_key_handoff(app, capability_id, m
     body = resp.json()
     assert body["error"] == "authentication_required"
     assert body["message"] == message
+    assert body["execute_url"] == f"/v1/capabilities/{capability_id}/execute"
     assert body["auth_handoff"]["reason"] == "auth_required"
     assert body["auth_handoff"]["recommended_path"] == "governed_api_key"
     auth_paths = {item["kind"]: item for item in body["auth_handoff"]["paths"]}

--- a/packages/api/tests/test_capability_execute.py
+++ b/packages/api/tests/test_capability_execute.py
@@ -4173,6 +4173,7 @@ async def test_direct_execute_get_with_api_key_returns_post_only_guidance(app):
 
     assert resp.status_code == 405
     assert "x-payment" not in resp.headers
+    assert resp.headers.get("allow") == "POST"
     body = resp.json()
     assert body["error"] == "method_not_allowed"
     assert body["execute_url"] == "/v1/capabilities/crm.object.describe/execute"

--- a/packages/mcp/src/api-client.ts
+++ b/packages/mcp/src/api-client.ts
@@ -456,6 +456,60 @@ function canonicalizeCredentialMode(mode: string | null): string | null {
   return mode === "byo" ? "byok" : mode;
 }
 
+function formatStructuredError(raw: Record<string, unknown>): string {
+  // FastAPI default errors often come through as {"detail": "..."}.
+  if (!raw.error && !raw.message && typeof raw.detail === "string") {
+    return raw.detail;
+  }
+
+  const parts: string[] = [];
+  const error = asString(raw.error);
+  const message = asString(raw.message) ?? asString(raw.detail);
+  const resolution = asString(raw.resolution);
+
+  if (error) {
+    parts.push(message ? `${error}: ${message}` : error);
+  } else if (message) {
+    parts.push(message);
+  }
+
+  if (resolution) parts.push(`resolution=${resolution}`);
+
+  const executeUrl = asString(raw.execute_url);
+  const resolveUrl = asString(raw.resolve_url);
+  const credentialModesUrl = asString(raw.credential_modes_url);
+  const searchUrl = asString(raw.search_url);
+  const requestId = asString(raw.request_id);
+
+  if (executeUrl) parts.push(`execute_url=${executeUrl}`);
+  if (resolveUrl) parts.push(`resolve_url=${resolveUrl}`);
+  if (credentialModesUrl) parts.push(`credential_modes_url=${credentialModesUrl}`);
+  if (searchUrl) parts.push(`search_url=${searchUrl}`);
+  if (requestId) parts.push(`request_id=${requestId}`);
+
+  const rawHandoff = isRecord(raw.auth_handoff) ? raw.auth_handoff : null;
+  if (rawHandoff) {
+    const handoffReason = asString(rawHandoff.reason);
+    const recommendedPath = asString(rawHandoff.recommended_path);
+    const rawPaths = Array.isArray(rawHandoff.paths)
+      ? rawHandoff.paths.filter((path): path is Record<string, unknown> => isRecord(path))
+      : [];
+
+    if (handoffReason) parts.push(`auth_handoff.reason=${handoffReason}`);
+    if (recommendedPath) parts.push(`auth_handoff.recommended_path=${recommendedPath}`);
+
+    const recommended = recommendedPath
+      ? rawPaths.find((path) => asString(path.kind) === recommendedPath)
+      : null;
+    const setupUrl = recommended ? asString(recommended.setup_url) : null;
+    const retryHeader = recommended ? asString(recommended.retry_header) : null;
+    if (setupUrl) parts.push(`setup_url=${setupUrl}`);
+    if (retryHeader) parts.push(`retry_header=${retryHeader}`);
+  }
+
+  return parts.length > 0 ? parts.join(" | ") : JSON.stringify(raw);
+}
+
 function asCredentialMode(v: unknown): string | null {
   return canonicalizeCredentialMode(asString(v));
 }
@@ -903,6 +957,17 @@ export function createApiClient(baseUrl?: string): RhumbApiClient {
 
       if (!res.ok) {
         const errBody = await res.text();
+        try {
+          const parsed: unknown = JSON.parse(errBody);
+          if (isRecord(parsed)) {
+            throw new Error(`Execute failed (${res.status}): ${formatStructuredError(parsed)}`);
+          }
+        } catch (err) {
+          // JSON.parse threw, or formatStructuredError threw — fall back to raw text.
+          if (err instanceof Error && err.message.startsWith("Execute failed")) {
+            throw err;
+          }
+        }
         throw new Error(`Execute failed (${res.status}): ${errBody}`);
       }
 
@@ -947,6 +1012,16 @@ export function createApiClient(baseUrl?: string): RhumbApiClient {
 
       if (!res.ok) {
         const errBody = await res.text();
+        try {
+          const parsed: unknown = JSON.parse(errBody);
+          if (isRecord(parsed)) {
+            throw new Error(`Estimate failed (${res.status}): ${formatStructuredError(parsed)}`);
+          }
+        } catch (err) {
+          if (err instanceof Error && err.message.startsWith("Estimate failed")) {
+            throw err;
+          }
+        }
         throw new Error(`Estimate failed (${res.status}): ${errBody}`);
       }
 

--- a/packages/mcp/src/api-client.ts
+++ b/packages/mcp/src/api-client.ts
@@ -769,7 +769,18 @@ export function createApiClient(baseUrl?: string): RhumbApiClient {
             suggestedCapabilities
           };
         }
-        throw new Error(`API returned ${res.status}`);
+        const errBody = await res.text();
+        try {
+          const parsed: unknown = JSON.parse(errBody);
+          if (isRecord(parsed)) {
+            throw new Error(`Resolve failed (${res.status}): ${formatStructuredError(parsed)}`);
+          }
+        } catch (err) {
+          if (err instanceof Error && err.message.startsWith("Resolve failed")) {
+            throw err;
+          }
+        }
+        throw new Error(`Resolve failed (${res.status}): ${errBody}`);
       }
 
       const payload: unknown = await res.json();

--- a/packages/mcp/tests/api-client.test.ts
+++ b/packages/mcp/tests/api-client.test.ts
@@ -591,3 +591,50 @@ describe("Rhumb MCP API client credential readiness", () => {
     });
   });
 });
+
+describe("Rhumb MCP API client error formatting", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces auth handoff details when execute returns structured 401", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => JSON.stringify({
+        error: "authentication_required",
+        message: "X-Rhumb-Key header required for CRM capability execution",
+        resolution: "Create or use a funded governed API key at /auth/login, then retry",
+        request_id: "req_test",
+        resolve_url: "/v1/capabilities/crm.object.describe/resolve",
+        credential_modes_url: "/v1/capabilities/crm.object.describe/credential-modes",
+        auth_handoff: {
+          reason: "auth_required",
+          recommended_path: "governed_api_key",
+          retry_url: "/v1/capabilities/crm.object.describe/execute",
+          docs_url: "/docs#resolve-mental-model",
+          paths: [
+            {
+              kind: "governed_api_key",
+              recommended: true,
+              setup_url: "/auth/login",
+              retry_header: "X-Rhumb-Key",
+            }
+          ]
+        }
+      })
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createApiClient("https://api.example.com/v1");
+
+    await expect(
+      client.executeCapability("crm.object.describe", { method: "POST", path: "/crm" })
+    ).rejects.toThrow(/setup_url=\/auth\/login/);
+    await expect(
+      client.executeCapability("crm.object.describe", { method: "POST", path: "/crm" })
+    ).rejects.toThrow(/retry_header=X-Rhumb-Key/);
+  });
+});

--- a/packages/mcp/tests/api-client.test.ts
+++ b/packages/mcp/tests/api-client.test.ts
@@ -288,6 +288,46 @@ describe("Rhumb MCP API client resolveCapability", () => {
     });
   });
 
+  it("surfaces auth handoff details when /resolve returns structured 401", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () =>
+        JSON.stringify({
+          error: "authentication_required",
+          message: "X-Rhumb-Key required",
+          resolution: "Create a governed key and retry",
+          request_id: "req_test",
+          resolve_url: "/v1/capabilities/crm.object.describe/resolve",
+          credential_modes_url: "/v1/capabilities/crm.object.describe/credential-modes",
+          auth_handoff: {
+            reason: "auth_required",
+            recommended_path: "governed_api_key",
+            retry_url: "/v1/capabilities/crm.object.describe/execute",
+            docs_url: "/docs#resolve-mental-model",
+            paths: [
+              {
+                kind: "governed_api_key",
+                recommended: true,
+                setup_url: "/auth/login",
+                retry_header: "X-Rhumb-Key",
+              },
+            ],
+          },
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createApiClient("https://api.example.com/v1");
+
+    await expect(client.resolveCapability("crm.object.describe")).rejects.toThrow(
+      /setup_url=\/auth\/login/
+    );
+    await expect(client.resolveCapability("crm.object.describe")).rejects.toThrow(
+      /retry_header=X-Rhumb-Key/
+    );
+  });
+
   it("canonicalizes legacy byo values across resolve response surfaces", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,


### PR DESCRIPTION
Adds machine-readable auth_handoff to the authenticated direct AUD-18 GET /v1/capabilities/{id}/execute 405 response, matching the 401 handoff shape and keeping MCP/web/operator surfaces from losing next-step guidance when they probe with the wrong method.

- Updates capability_execute.py 405 envelope
- Extends focused test in packages/api/tests/test_capability_execute.py

Verification: pytest -k direct_execute_get (focused slice).