### PR TITLE
fix(aud-18): rewrite v1 navigation urls on v2 provider execute

### DIFF
--- a/packages/api/routes/providers_v2.py
+++ b/packages/api/routes/providers_v2.py
@@ -78,6 +78,15 @@ _RESPONSE_HEADER_NAMES = [
     "X-Rhumb-Rate-Remaining",
 ]
 
+_V2_NAVIGATION_URL_KEYS = {
+    "search_url",
+    "resolve_url",
+    "estimate_url",
+    "credential_modes_url",
+    "retry_url",
+    "execute_url",
+}
+
 
 # ---------------------------------------------------------------------------
 # Request / response models
@@ -199,6 +208,39 @@ def _parse_endpoint_pattern(endpoint_pattern: str | None) -> tuple[str | None, s
         return None, None
     method, path = endpoint_pattern.strip().split(" ", 1)
     return method.upper(), path.strip()
+
+
+def _rewrite_v1_capabilities_url(url: str) -> str:
+    if not url.startswith("/v1/capabilities"):
+        return url
+    return f"/v2{url[3:]}"
+
+
+def _rewrite_endpoint_pattern(endpoint_pattern: str) -> str:
+    method, path = _parse_endpoint_pattern(endpoint_pattern)
+    if method is None or path is None:
+        return endpoint_pattern
+    rewritten_path = _rewrite_v1_capabilities_url(path)
+    if rewritten_path == path:
+        return endpoint_pattern
+    return f"{method} {rewritten_path}"
+
+
+def _rewrite_navigation_urls(payload: Any) -> Any:
+    """Rewrite any v1 capability navigation URLs returned through the v2 Layer 1 surface."""
+    if isinstance(payload, dict):
+        rewritten: dict[str, Any] = {}
+        for key, value in payload.items():
+            if key in _V2_NAVIGATION_URL_KEYS and isinstance(value, str):
+                rewritten[key] = _rewrite_v1_capabilities_url(value)
+            elif key == "endpoint_pattern" and isinstance(value, str):
+                rewritten[key] = _rewrite_endpoint_pattern(value)
+            else:
+                rewritten[key] = _rewrite_navigation_urls(value)
+        return rewritten
+    if isinstance(payload, list):
+        return [_rewrite_navigation_urls(item) for item in payload]
+    return payload
 
 
 def _layer1_cost(provider_cost_usd: float) -> dict[str, float]:
@@ -949,6 +991,7 @@ async def execute_on_provider(
         estimate_response.json(),
         provider_id=provider_public_slug,
     )
+    estimate_body = _rewrite_navigation_urls(estimate_body)
     if estimate_response.status_code != 200:
         return JSONResponse(
             status_code=estimate_response.status_code,
@@ -1014,6 +1057,7 @@ async def execute_on_provider(
         execute_response.json(),
         provider_id=provider_public_slug,
     )
+    body = _rewrite_navigation_urls(body)
 
     t_total_ms = int((time.monotonic() - t_start) * 1000)
 

--- a/packages/api/tests/test_providers_v2.py
+++ b/packages/api/tests/test_providers_v2.py
@@ -1347,6 +1347,39 @@ class TestExecuteOnProvider:
 
         assert resp.status_code == 402  # BUDGET_EXCEEDED
 
+    def test_execute_rewrites_v1_navigation_urls_in_estimate_failure(self, client):
+        """Layer 1 v2 surface should not leak v1 capability navigation URLs."""
+        with patch("routes.providers_v2.supabase_fetch", side_effect=_mock_supabase_fetch):
+            with patch("routes.providers_v2._forward_internal") as mock_forward:
+                estimate_resp = MagicMock()
+                estimate_resp.status_code = 401
+                estimate_resp.json.return_value = {
+                    "detail": "Invalid or expired governed API key",
+                    "execute_url": f"/v1/capabilities/{_TEST_CAPABILITY}/execute",
+                    "resolve_url": f"/v1/capabilities/{_TEST_CAPABILITY}/resolve",
+                    "credential_modes_url": f"/v1/capabilities/{_TEST_CAPABILITY}/credential-modes",
+                    "auth_handoff": {
+                        "reason": "invalid_api_key",
+                        "retry_url": f"/v1/capabilities/{_TEST_CAPABILITY}/execute",
+                        "paths": [{"kind": "governed_api_key", "setup_url": "/auth/login"}],
+                    },
+                }
+                estimate_resp.headers = {}
+                mock_forward.return_value = estimate_resp
+
+                resp = client.post(
+                    f"/v2/providers/{_TEST_PROVIDER_SLUG}/execute",
+                    json={"capability": _TEST_CAPABILITY, "parameters": {}},
+                )
+
+        assert resp.status_code == 401
+        body = resp.json()
+        assert body["execute_url"] == f"/v2/capabilities/{_TEST_CAPABILITY}/execute"
+        assert body["resolve_url"] == f"/v2/capabilities/{_TEST_CAPABILITY}/resolve"
+        assert body["credential_modes_url"] == f"/v2/capabilities/{_TEST_CAPABILITY}/credential-modes"
+        assert body["auth_handoff"]["retry_url"] == f"/v2/capabilities/{_TEST_CAPABILITY}/execute"
+        assert body["auth_handoff"]["paths"][0]["setup_url"] == "/auth/login"
+
 
 # ---------------------------------------------------------------------------
 # Layer 1 cost calculation


### PR DESCRIPTION
Layer 1 v2 provider execute was leaking v1 capability navigation URLs (execute_url / resolve_url / credential_modes_url / auth_handoff.retry_url) when the v1 estimate/execute path returned structured handoff payloads.

This adds a small recursive URL rewriter (mirrors resolve_v2) and applies it to both the estimate failure passthrough and the execute response body.

Test: adds a focused regression proving /v2/providers/{provider}/execute returns /v2/capabilities/* URLs on a 401 estimate failure.