### PR TITLE
fix(aud-18): rewrite embedded v1 capability urls on v2

### DIFF
--- a/packages/api/routes/resolve_v2.py
+++ b/packages/api/routes/resolve_v2.py
@@ -251,6 +251,10 @@ def _rewrite_navigation_urls(payload: Any) -> Any:
         return rewritten
     if isinstance(payload, list):
         return [_rewrite_navigation_urls(item) for item in payload]
+    if isinstance(payload, str) and "/v1/capabilities" in payload:
+        # Only rewrite the v1 capabilities namespace when it appears inside
+        # human-readable error messages (e.g. resolution strings).
+        return payload.replace("/v1/capabilities", "/v2/capabilities")
     return payload
 
 

--- a/packages/api/tests/test_resolve_v2.py
+++ b/packages/api/tests/test_resolve_v2.py
@@ -825,6 +825,8 @@ async def test_v2_resolve_not_found_rewrites_search_url(app):
 
     assert resp.status_code == 404
     body = resp.json()
+    assert "/v1/capabilities" not in body["resolution"]
+    assert "/v2/capabilities" in body["resolution"]
     assert body["search_url"] == "/v2/capabilities?search=nonexistent"
 
 


### PR DESCRIPTION
Resolve v2 was already rewriting structured navigation URL fields (search_url/resolve_url/etc), but the v1 capability-not-found 404 includes a human `resolution` string that still referenced `GET /v1/capabilities`.

This extends the v2 URL rewriter to also rewrite embedded `/v1/capabilities` mentions inside strings, and adds a focused regression asserting `/v2/capabilities` is referenced in the v2 404 resolution.