### PR TITLE
fix(aud-18): add auth handoff to v2 billing 401s

### DIFF
--- a/packages/api/routes/billing_v2.py
+++ b/packages/api/routes/billing_v2.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import re
+import uuid
 from typing import Any
 
-from fastapi import APIRouter, Header, HTTPException, Query
+from fastapi import APIRouter, Header, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
 
 from schemas.agent_identity import AgentIdentityStore, get_agent_identity_store
 from services.billing_events import (
@@ -66,12 +68,70 @@ def _get_identity_store() -> AgentIdentityStore:
 
 
 async def _require_org(api_key: str | None) -> str:
-    """Validate API key and return org_id."""
+    raise NotImplementedError("_require_org now requires a Request; call _require_org_or_401")
+
+
+def _auth_handoff(*, reason: str, retry_url: str) -> dict[str, Any]:
+    return {
+        "reason": reason,
+        "recommended_path": "governed_api_key",
+        "retry_url": retry_url,
+        "docs_url": "/docs#resolve-mental-model",
+        "paths": [
+            {
+                "kind": "governed_api_key",
+                "recommended": True,
+                "setup_url": "/auth/login",
+                "retry_header": "X-Rhumb-Key",
+                "summary": "Default for dashboards and most repeat agent traffic.",
+                "requires_human_setup": True,
+                "automatic_after_setup": True,
+            }
+        ],
+    }
+
+
+def _missing_governed_key_response(raw_request: Request) -> JSONResponse:
+    request_id = getattr(raw_request.state, "request_id", None) or str(uuid.uuid4())
+    detail = "Missing X-Rhumb-Key header"
+    retry_url = str(raw_request.url.path)
+    return JSONResponse(
+        status_code=401,
+        content={
+            "detail": detail,
+            "error": "missing_api_key",
+            "message": detail,
+            "resolution": "Provide a funded governed API key via /auth/login, then retry.",
+            "request_id": request_id,
+            "auth_handoff": _auth_handoff(reason="missing_api_key", retry_url=retry_url),
+        },
+    )
+
+
+def _invalid_governed_key_response(raw_request: Request) -> JSONResponse:
+    request_id = getattr(raw_request.state, "request_id", None) or str(uuid.uuid4())
+    detail = "Invalid or expired API key"
+    retry_url = str(raw_request.url.path)
+    return JSONResponse(
+        status_code=401,
+        content={
+            "detail": detail,
+            "error": "invalid_api_key",
+            "message": detail,
+            "resolution": "Create or use a funded governed API key via /auth/login, then retry.",
+            "request_id": request_id,
+            "auth_handoff": _auth_handoff(reason="invalid_api_key", retry_url=retry_url),
+        },
+    )
+
+
+async def _require_org_or_401(raw_request: Request, api_key: str | None) -> str | JSONResponse:
+    """Validate governed API key and return org_id, or a structured 401 response."""
     if not api_key:
-        raise HTTPException(status_code=401, detail="Missing X-Rhumb-Key header")
+        return _missing_governed_key_response(raw_request)
     agent = await _get_identity_store().verify_api_key_with_agent(api_key)
     if agent is None:
-        raise HTTPException(status_code=401, detail="Invalid or expired API key")
+        return _invalid_governed_key_response(raw_request)
     return agent.organization_id
 
 
@@ -239,19 +299,22 @@ def _summary_to_response(summary: BillingEventSummary) -> dict[str, Any]:
     }
 
 
-@router.get("/events")
+@router.get("/events", response_model=None)
 async def query_billing_events(
+    raw_request: Request,
     x_rhumb_key: str | None = Header(None, alias="X-Rhumb-Key"),
     event_type: str | None = Query(None, description="Filter by event type"),
     limit: int = Query(50, ge=1, le=200),
     since: str | None = Query(None, description="ISO timestamp filter"),
-) -> dict[str, Any]:
+) -> dict[str, Any] | JSONResponse:
     """Query billing events for the authenticated org.
 
     Returns events from the structured billing event stream,
     newest first.
     """
-    org_id = await _require_org(x_rhumb_key)
+    org_id = await _require_org_or_401(raw_request, x_rhumb_key)
+    if isinstance(org_id, JSONResponse):
+        return org_id
     stream = get_billing_event_stream()
 
     # Parse filters
@@ -299,17 +362,20 @@ async def query_billing_events(
     }
 
 
-@router.get("/summary")
+@router.get("/summary", response_model=None)
 async def billing_summary(
+    raw_request: Request,
     x_rhumb_key: str | None = Header(None, alias="X-Rhumb-Key"),
     period: str | None = Query(None, description="Period filter: YYYY-MM or YYYY-MM-DD"),
-) -> dict[str, Any]:
+) -> dict[str, Any] | JSONResponse:
     """Get aggregate billing summary for the authenticated org.
 
     Includes totals, breakdowns by provider and capability,
     and event counts.
     """
-    org_id = await _require_org(x_rhumb_key)
+    org_id = await _require_org_or_401(raw_request, x_rhumb_key)
+    if isinstance(org_id, JSONResponse):
+        return org_id
     stream = get_billing_event_stream()
     summary = stream.summarize(org_id=org_id, period=period)
 

--- a/packages/api/tests/test_billing_v2.py
+++ b/packages/api/tests/test_billing_v2.py
@@ -1,0 +1,52 @@
+"""Tests for v2 Billing endpoints (routes/billing_v2.py)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def app():
+    from fastapi import FastAPI
+    from routes.billing_v2 import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    from fastapi.testclient import TestClient
+
+    return TestClient(app)
+
+
+class TestBillingV2Auth:
+    def test_summary_requires_auth_handoff(self, client):
+        resp = client.get("/v2/billing/summary")
+        assert resp.status_code == 401
+        body = resp.json()
+        assert body["detail"] == "Missing X-Rhumb-Key header"
+        assert body["error"] == "missing_api_key"
+        assert body["auth_handoff"]["reason"] == "missing_api_key"
+        assert body["auth_handoff"]["retry_url"] == "/v2/billing/summary"
+
+    def test_events_invalid_key_includes_auth_handoff(self, client):
+        mock_store = MagicMock()
+        mock_store.verify_api_key_with_agent = AsyncMock(return_value=None)
+
+        with patch("routes.billing_v2._get_identity_store", return_value=mock_store):
+            resp = client.get(
+                "/v2/billing/events",
+                headers={"X-Rhumb-Key": "rk_invalid"},
+            )
+
+        assert resp.status_code == 401
+        body = resp.json()
+        assert body["detail"] == "Invalid or expired API key"
+        assert body["error"] == "invalid_api_key"
+        assert body["auth_handoff"]["reason"] == "invalid_api_key"
+        assert body["auth_handoff"]["retry_url"] == "/v2/billing/events"


### PR DESCRIPTION
`/v2/billing/*` endpoints previously returned bare FastAPI `{"detail": ...}` 401s for missing/invalid governed keys.

This preserves the legacy `detail` strings but adds a structured envelope with `error`, `message`, `resolution`, `request_id`, and `auth_handoff` pointing to `/auth/login`.

Adds focused regression coverage in `packages/api/tests/test_billing_v2.py`.