### PR TITLE
fix(aud-18): add explicit receipt/explanation not-found codes

### DIFF
--- a/packages/api/routes/explanations_v2.py
+++ b/packages/api/routes/explanations_v2.py
@@ -28,7 +28,7 @@ async def get_route_explanation(explanation_id: str) -> dict[str, Any]:
         explanation = await get_persisted_explanation(explanation_id)
     if explanation is None:
         raise RhumbError(
-            "CAPABILITY_NOT_FOUND",
+            "EXPLANATION_NOT_FOUND",
             message=f"Explanation '{explanation_id}' not found.",
             detail=(
                 "Explanations are stored in-memory and may expire. "

--- a/packages/api/routes/receipts_v2.py
+++ b/packages/api/routes/receipts_v2.py
@@ -30,7 +30,7 @@ async def get_receipt(receipt_id: str) -> dict[str, Any]:
     receipt = await service.get_receipt(receipt_id)
     if receipt is None:
         raise RhumbError(
-            "CAPABILITY_NOT_FOUND",
+            "RECEIPT_NOT_FOUND",
             message=f"No receipt found with id '{receipt_id}'",
             detail="Check the receipt_id from an execution response, or query receipts at GET /v2/receipts",
         )
@@ -48,7 +48,7 @@ async def get_receipt_explanation(receipt_id: str) -> dict[str, Any]:
     receipt = await service.get_receipt(receipt_id)
     if receipt is None:
         raise RhumbError(
-            "CAPABILITY_NOT_FOUND",
+            "RECEIPT_NOT_FOUND",
             message=f"No receipt found with id '{receipt_id}'",
             detail="Check the receipt_id from an execution response.",
         )

--- a/packages/api/services/error_envelope.py
+++ b/packages/api/services/error_envelope.py
@@ -85,6 +85,20 @@ ERROR_CODES: dict[str, ErrorCodeDef] = {
         retryable=False,
         description="Recipe ID does not exist",
     ),
+    "RECEIPT_NOT_FOUND": ErrorCodeDef(
+        code="RECEIPT_NOT_FOUND",
+        category=ErrorCategory.CLIENT,
+        http_status=404,
+        retryable=False,
+        description="Receipt ID does not exist",
+    ),
+    "EXPLANATION_NOT_FOUND": ErrorCodeDef(
+        code="EXPLANATION_NOT_FOUND",
+        category=ErrorCategory.CLIENT,
+        http_status=404,
+        retryable=False,
+        description="Explanation ID does not exist",
+    ),
     "CREDENTIAL_INVALID": ErrorCodeDef(
         code="CREDENTIAL_INVALID",
         category=ErrorCategory.AUTH,

--- a/packages/api/tests/test_explanations_v2.py
+++ b/packages/api/tests/test_explanations_v2.py
@@ -93,3 +93,20 @@ def test_get_explanation_canonicalizes_same_provider_alias_text_when_persisted_i
         "Brave Search (brave-search-api) selected over people-data-labs."
     )
     assert "brave-search-api-api" not in body["data"]["human_summary"]
+
+
+def test_get_explanation_not_found_uses_explanation_code():
+    from app import create_app
+
+    client = TestClient(create_app())
+
+    with (
+        patch("routes.explanations_v2.get_explanation", return_value=None),
+        patch("routes.explanations_v2.get_persisted_explanation", new_callable=AsyncMock, return_value=None),
+    ):
+        resp = client.get("/v2/explanations/rexp_missing")
+
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["error"]["code"] == "EXPLANATION_NOT_FOUND"
+    assert "rexp_missing" in body["error"]["message"]

--- a/packages/api/tests/test_receipts_v2.py
+++ b/packages/api/tests/test_receipts_v2.py
@@ -25,8 +25,8 @@ def test_get_receipt_not_found(client):
         resp = client.get("/v2/receipts/rcpt_nonexistent")
         assert resp.status_code == 404
         body = resp.json()
-        # FastAPI serializes HTTPException detail — check for the error message
-        assert "rcpt_nonexistent" in str(body)
+        assert body["error"]["code"] == "RECEIPT_NOT_FOUND"
+        assert "rcpt_nonexistent" in body["error"]["message"]
 
 
 def test_get_receipt_found(client):


### PR DESCRIPTION
`/v2/receipts/*` and `/v2/explanations/*` were returning `CAPABILITY_NOT_FOUND` for missing receipt/explanation IDs.

This adds explicit error codes to the canonical registry:
- RECEIPT_NOT_FOUND
- EXPLANATION_NOT_FOUND

And updates both routes + focused regressions so client error handling and observability don’t misclassify these misses as capability discovery problems.