### PR TITLE
fix(web): align homepage MCP quickstart with Resolve tools

### DIFF
--- a/packages/astro-web/src/components/QuickstartSection.astro
+++ b/packages/astro-web/src/components/QuickstartSection.astro
@@ -4,10 +4,10 @@ import CopyTextButton from "./CopyTextButton.tsx";
 const mcpCode = `$ npx -y --package rhumb-mcp@latest rhumb-mcp
 > starting Rhumb MCP server...
 > connected
-> tools: find_services, get_score, get_failure_modes, resolve_execute
-> find_services("company research")
-> get_score("Acme API", "company.research")
-> resolve_execute("best_route", "company.research")`;
+> tools: find_services, get_score, get_failure_modes, resolve_capability, estimate_capability, execute_capability...
+> find_services({"query":"company research"})
+> resolve_capability({"capability":"search.query","credential_mode":"rhumb_managed"})
+> estimate_capability({"capability":"search.query","credential_mode":"rhumb_managed"})`;
 ---
 
 <section id="quickstart" class="home-section border-b border-white/10 bg-rhumb-deep">


### PR DESCRIPTION
## Summary
- replaces the stale homepage MCP quickstart pseudo-tool `resolve_execute` with current Resolve tool names
- shows real JSON-shaped example calls for `find_services`, `resolve_capability`, and `estimate_capability`
- keeps first-run docs aligned with the current 21-tool Resolve MCP surface instead of advertising a nonexistent tool

## Verification
- `rhumb-page-ship-check.sh --source-ready --path / --path /quickstart` passed local Astro build/artifact checks
- grep confirmed no `resolve_execute` remains in public web/docs/README/MCP README copy

## Release note
Source-ready only. No production deploy spent under bundled-release policy.