### PR TITLE
Fix remaining machine-readable public count drift

### DIFF
--- a/agent-capabilities.json
+++ b/agent-capabilities.json
@@ -125,11 +125,11 @@
     }
   },
   "coverage": {
-    "services": 999,
-    "capabilities": 435,
+    "services": 1038,
+    "capabilities": 415,
     "domains": 50,
     "categories": 92,
-    "providers_with_execution": 18,
+    "providers_with_execution": 16,
     "credential_modes": [
       "byok",
       "rhumb_managed",

--- a/packages/astro-web/public/.well-known/agent-capabilities.json
+++ b/packages/astro-web/public/.well-known/agent-capabilities.json
@@ -125,11 +125,11 @@
     }
   },
   "coverage": {
-    "services": 999,
-    "capabilities": 435,
+    "services": 1038,
+    "capabilities": 415,
     "domains": 50,
     "categories": 92,
-    "providers_with_execution": 18,
+    "providers_with_execution": 16,
     "credential_modes": [
       "byok",
       "rhumb_managed",

--- a/packages/astro-web/src/pages/llms.txt.ts
+++ b/packages/astro-web/src/pages/llms.txt.ts
@@ -6,14 +6,11 @@ import { PUBLIC_TRUTH } from '../lib/public-truth';
 export const GET: APIRoute = async () => {
   const apiBase = import.meta.env.PUBLIC_API_BASE_URL ?? "https://api.rhumb.dev/v1";
 
-  const [services, categories, capRes] = await Promise.all([
+  const [services, categories] = await Promise.all([
     getServices(),
     getCategories(),
-    fetch(`${apiBase}/capabilities?limit=1&offset=0`, { headers: { "X-Rhumb-Client": "web" } })
-      .then((r) => r.ok ? r.json() : null)
-      .catch(() => null),
   ]);
-  const totalCapabilities = capRes?.data?.total ?? PUBLIC_TRUTH.capabilities;
+  const totalCapabilities = PUBLIC_TRUTH.capabilities;
   const routeList = PRIMARY_ACTIVATION_PATHS
     .map((route) => `- ${route.title}: https://rhumb.dev${route.href} — ${route.summary}`)
     .join("\n");


### PR DESCRIPTION
## Summary

Follow-up to #54: align the remaining machine-readable public surfaces with the same public truth already used by the site/docs.

- `.well-known/agent-capabilities.json`: 1,038 services, 415 capabilities, 16 execution providers
- root `agent-capabilities.json`: same mirror values
- `llms.txt` route: use `PUBLIC_TRUTH.capabilities` instead of a live API total that was still returning 435 and reintroducing drift

## Verification

- `cd packages/astro-web && npm run build`
- Source grep for stale `999`, `435`, `18 callable`, `rhumb_live_`, and bare `npx rhumb-mcp@latest` only finds negative contract-test assertions.
